### PR TITLE
[Refactor] タイムライン取得機能をリファクタリング

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 .env
 .env.backup
 .phpunit.result.cache
+.vscode
 Homestead.json
 Homestead.yaml
 npm-debug.log

--- a/app/Http/Controllers/TimelineController.php
+++ b/app/Http/Controllers/TimelineController.php
@@ -12,69 +12,35 @@ class TimelineController extends Controller
 {
     public function homeTimeline(GetTimeline $request)
     {
-        [$since_id, $until_id, $count] = $this->destructLimitOptions($request);
+        [$sinceId, $untilId, $count] = $this->destructLimitOptions($request);
 
         //temporarily using first user
         $user = \App\User::first();
 
-        $follow_user_ids = $user->following()->pluck('follow_user_id');
-        $postQuery = Post::wherein('user_id', $follow_user_ids)
-            ->with(['good' => function ($query) use ($user) {
-                $query->where('user_id', $user->user_id);
-            }]);
-        
-        $posts = $this->limitPosts($postQuery, $since_id, $until_id, $count)
-            ->get();
-
+        $posts = $user->homeTimeline($sinceId, $untilId, $count);
         return new TimelineCollection($posts);
     }
 
     public function userTimeline(GetTimeLine $request)
     {
-        [$since_id, $until_id, $count] = $this->destructLimitOptions($request);
+        [$sinceId, $untilId, $count] = $this->destructLimitOptions($request);
         
         //temporarily using first user
         $user = \App\User::first();
-        $target_user_id = $request->input('user_id', $user->user_id);
+        $targetUserId = $request->input('user_id') ?? $user->user_id;
 
-        $postQuery = Post::where('user_id', $target_user_id)
-            ->with(['good' => function ($query) use ($user) {
-                $query->where('user_id', $user->user_id);
-            }]);
-
-        $posts = $this->limitPosts($postQuery, $since_id, $until_id, $count)
-            ->get();
-
+        $posts = $user->userTimeline($targetUserId, $sinceId, $untilId, $count);
         return new TimelineCollection($posts);
     }
 
     private function destructLimitOptions()
     {
         $request = request();
-        $since_id = $request->input('since_id');
-        $until_id = $request->input('until_id');
+        $sinceId = $request->input('since_id');
+        $untilId = $request->input('until_id');
         $count = $request->input('count', 10);
         $count = min($count, 50);
 
-        return [$since_id, $until_id, $count];
-    }
-
-    private function limitPosts($query, $since_id, $until_id, $count)
-    {
-        if ($since_id) {
-            $query->where('posts.post_id', '>', $since_id);
-        }
-
-        if ($until_id) {
-            $query->where('posts.post_id', '<=', $until_id);
-        }
-
-        if ($count) {
-            $query->limit($count);
-        }
-
-        $query->orderby("posts.post_id");
-
-        return $query;
+        return [$sinceId, $untilId, $count];
     }
 }

--- a/app/Http/Controllers/TimelineController.php
+++ b/app/Http/Controllers/TimelineController.php
@@ -17,7 +17,7 @@ class TimelineController extends Controller
         //temporarily using first user
         $user = \App\User::first();
 
-        $follow_user_ids = $user->following->pluck('follow_user_id');
+        $follow_user_ids = $user->following()->pluck('follow_user_id');
         $postQuery = Post::wherein('user_id', $follow_user_ids)
             ->with(['good' => function ($query) use ($user) {
                 $query->where('user_id', $user->user_id);

--- a/app/Post.php
+++ b/app/Post.php
@@ -11,6 +11,31 @@ class Post extends Model
 
     protected $primaryKey = 'post_id';
 
+    public function scopeGetBetween($query, $sinceId, $untilId, $count = null)
+    {
+        $keyName = $this->getQualifiedKeyName();
+
+        if ($sinceId) {
+            $query->where($keyName, '>', $sinceId);
+        }
+
+        if ($untilId) {
+            $query->where($keyName, '<=', $untilId);
+        }
+
+        if ($count) {
+            $query->limit($count);
+            $query->orderBy($keyName, 'desc');
+        }
+    }
+
+    public function scopeWithGoodedByUser($postQuery, $user_id)
+    {
+        $postQuery->with(['good' => function ($goodQuery) use ($user_id) {
+            $goodQuery->where('user_id', $user_id);
+        }]);
+    }
+    
     public function user()
     {
         return $this->belongsTo(User::class, 'user_id');

--- a/app/User.php
+++ b/app/User.php
@@ -16,6 +16,22 @@ class User extends Authenticatable implements JWTSubject
     protected $keyType = 'string';
     public $incrementing = false;
 
+    public function homeTimeline($sinceId = null, $untilId = null, $count = null)
+    {
+        return Post::getBetween($sinceId, $untilId, $count)
+            ->whereIn('user_id', $this->following()->pluck('follow_user_id'))
+            ->withGoodedByUser($this->user_id)
+            ->get();
+    }
+
+    public function userTimeline($user_id, $sinceId = null, $untilId = null, $count = null)
+    {
+        return Post::getBetween($sinceId, $untilId, $count)
+            ->where('user_id', $user_id)
+            ->withGoodedByUser($this->user_id)
+            ->get();
+    }
+
     public function getJWTIdentifier()
     {
         return $this->getKey();


### PR DESCRIPTION
## 現状
home_timeline, user_timelineの投稿取得ロジックがコントローラーにベタ書きされてる。

## 修正内容
UserモデルとPostモデルにロジックを移動した。
* Userモデルにタイムライン取得の処理を移動
* Postモデルに期間で絞り込むためのローカルスコープを定義
* Postモデルに特定のユーザーからのgoodをeagarロードするローカルスコープを定義