### PR TITLE
[Fix] タイムライン取得のバグたち修正

### DIFF
--- a/app/Http/Resources/Image.php
+++ b/app/Http/Resources/Image.php
@@ -15,6 +15,7 @@ class Image extends JsonResource
     public function toArray($request)
     {
         return [
+            'image_id' => $this->image_id,
             'image_url' => $this->image_url,
             'dish_name' => $this->dish_name
         ];

--- a/app/Http/Resources/Timeline.php
+++ b/app/Http/Resources/Timeline.php
@@ -12,9 +12,9 @@ class Timeline extends JsonResource
             'post_id' => $this->post_id,
             'content' => $this->content,
             'user' => [
-                'user_id' => $this->user_id,
-                'username' => $this->username,
-                'user_icon' => $this->icon_url,
+                'user_id' => $this->user->user_id,
+                'username' => $this->user->username,
+                'user_icon' => $this->user->icon_url,
             ],
             'like_flag' => $this->like_flag,
             'good_count' => $this->good_count,

--- a/app/Http/Resources/Timeline.php
+++ b/app/Http/Resources/Timeline.php
@@ -19,7 +19,7 @@ class Timeline extends JsonResource
             'like_flag' => $this->like_flag,
             'good_count' => $this->good_count,
             'comment_count' => $this->comment_count,
-            'gooded' => $this->good->isNotEmpty(),
+            'good_flag' => $this->good->isNotEmpty(),
             'images' => Image::collection($this->image),
             'restaurant' => [
                 'restaurant_id' => $this->restaurant_id,

--- a/app/Post.php
+++ b/app/Post.php
@@ -11,6 +11,10 @@ class Post extends Model
 
     protected $primaryKey = 'post_id';
 
+    protected $casts = [
+        'like_flag' => 'bool'
+    ];
+
     public function scopeGetBetween($query, $sinceId, $untilId, $count = null)
     {
         $keyName = $this->getQualifiedKeyName();

--- a/app/User.php
+++ b/app/User.php
@@ -22,6 +22,7 @@ class User extends Authenticatable implements JWTSubject
             ->whereIn('user_id', $this->following()->pluck('follow_user_id'))
             ->withGoodedByUser($this->user_id)
             ->with('image')
+            ->with('user')
             ->get();
     }
 
@@ -31,6 +32,7 @@ class User extends Authenticatable implements JWTSubject
             ->where('user_id', $user_id)
             ->withGoodedByUser($this->user_id)
             ->with('image')
+            ->with('user')
             ->get();
     }
 


### PR DESCRIPTION
## 現状
タイムライン情報を取得したら
* user.username, user.icon_urlがnullになってる。
* like_flagがnumber型になってる。
* images.image_idが抜けてる。
* boolには_flagをつけるって決めたはずだけど、goodedって決まりにのっとってない。

## 変更内容
上記問題を修正
