### PR TITLE
Add 新規投稿に関わる処理を作成

### DIFF
--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Image;
+use App\User;
+use App\Http\Requests\StoreImage;
+use Illuminate\Http\Request;
+
+class PostController extends Controller
+{
+    public function storeImage(StoreImage $request)
+    {
+        //認証済みユーザーをとる
+        $user = User::first();
+
+        $path = $request->image->store('public');
+
+        $image = Image::create([
+            'user_id' => $user->user_id,
+            'image_url' => basename($path),
+            'dish_name' => $request->dish_name ?? ''
+        ]);
+
+        return response()->json(['image_id' => $image->image_id], 201);
+    }
+}

--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -3,12 +3,32 @@
 namespace App\Http\Controllers;
 
 use App\Image;
+use App\Post;
 use App\User;
+use App\Http\Requests\StorePost;
 use App\Http\Requests\StoreImage;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
 
 class PostController extends Controller
 {
+    public function storePost(StorePost $request)
+    {
+        $attributes = $request->validated();
+        unset($attributes['image_ids']);
+
+        //認証済みユーザーをとる
+        $attributes['user_id'] = User::first()->user_id;
+
+        //restaurant_name & restaurant_addressをぐるなびAPIから取ってくる
+        $attributes['restaurant_name'] = '鳥貴族';
+        $attributes['restaurant_address'] = '〒589-0011 大阪府';
+
+        $images = $this->verifyUserCanLinkImages($request->image_ids);
+
+        return Post::createAndLinkImage($attributes, $images);
+    }
+
     public function storeImage(StoreImage $request)
     {
         //認証済みユーザーをとる
@@ -23,5 +43,17 @@ class PostController extends Controller
         ]);
 
         return response()->json(['image_id' => $image->image_id], 201);
+    }
+
+    private function verifyUserCanLinkImages(array $image_ids)
+    {
+        $images = Image::find($image_ids);
+        abort_if($images->count() !== count($image_ids), 422, 'image_ids are invalid');
+
+        $images->each(function ($image) {
+            //認証済みユーザーで認可する
+            $this->authorizeForUser(User::first(), 'link_image', $image);
+        });
+        return $images;
     }
 }

--- a/app/Http/Requests/StoreImage.php
+++ b/app/Http/Requests/StoreImage.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreImage extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'image' => 'required|file|max:5120|mimes:jpeg,png',
+            'dish_name' => ''
+        ];
+    }
+}

--- a/app/Http/Requests/StorePost.php
+++ b/app/Http/Requests/StorePost.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StorePost extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'content' => 'required',
+            'like_flag' => 'boolean',
+            'restaurant_id' => 'required',
+            'image_ids' => 'bail|required|array|min:1|max:4',
+            'image_ids.*' => 'integer'
+        ];
+    }
+}

--- a/app/Image.php
+++ b/app/Image.php
@@ -7,7 +7,6 @@ use Illuminate\Database\Eloquent\Model;
 class Image extends Model
 {
     protected $primaryKey = 'image_id';
-    public $incrementing = false;
     public $timestamps = false;
 
     public function post()

--- a/app/Image.php
+++ b/app/Image.php
@@ -20,4 +20,9 @@ class Image extends Model
     {
         return $this->belongsTo(Post::class, 'post_id');
     }
+
+    public function user()
+    {
+        return $this->belongsTo(User::class, 'user_id');
+    }
 }

--- a/app/Image.php
+++ b/app/Image.php
@@ -10,6 +10,12 @@ class Image extends Model
     protected $guarded = [];
     public $timestamps = false;
 
+    public function linkPost($postId)
+    {
+        $this->post_id = $postId;
+        $this->save();
+    }
+
     public function post()
     {
         return $this->belongsTo(Post::class, 'post_id');

--- a/app/Image.php
+++ b/app/Image.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Model;
 class Image extends Model
 {
     protected $primaryKey = 'image_id';
+    protected $guarded = [];
     public $timestamps = false;
 
     public function post()

--- a/app/Post.php
+++ b/app/Post.php
@@ -4,12 +4,14 @@ namespace App;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Facades\DB;
 
 class Post extends Model
 {
     use SoftDeletes;
 
     protected $primaryKey = 'post_id';
+    protected $guarded = [];
 
     protected $casts = [
         'like_flag' => 'bool'
@@ -38,6 +40,20 @@ class Post extends Model
         $postQuery->with(['good' => function ($goodQuery) use ($user_id) {
             $goodQuery->where('user_id', $user_id);
         }]);
+    }
+
+    public static function createAndLinkImage($attributes, $images)
+    {
+        return DB::transaction(function () use ($attributes, $images) {
+            $post = static::create($attributes);
+            $post->linkImage($images);
+            return $post;
+        });
+    }
+
+    public function linkImage($images)
+    {
+        $images->each->linkPost($this->post_id);
     }
     
     public function user()

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -25,6 +25,8 @@ class AuthServiceProvider extends ServiceProvider
     {
         $this->registerPolicies();
 
-        //
+        Gate::define('link_image', function ($user, $image) {
+            return $image->post_id === null && $user->user_id === $image->user_id;
+        });
     }
 }

--- a/app/User.php
+++ b/app/User.php
@@ -86,4 +86,9 @@ class User extends Authenticatable implements JWTSubject
     {
         return $this->hasMany(ToGo::class, 'user_id');
     }
+    
+    public function image()
+    {
+        return $this->hasMany(Image::class, 'user_id');
+    }
 }

--- a/database/migrations/2020_07_07_004536_create_posts_table.php
+++ b/database/migrations/2020_07_07_004536_create_posts_table.php
@@ -17,9 +17,9 @@ class CreatePostsTable extends Migration
             $table->bigIncrements('post_id');
             $table->string('content');
             $table->string('user_id');
-            $table->boolean('like_flag');
-            $table->unsignedInteger('good_count');
-            $table->unsignedInteger('comment_count');
+            $table->boolean('like_flag')->default(false);
+            $table->unsignedInteger('good_count')->default(0);
+            $table->unsignedInteger('comment_count')->default(0);
             $table->string('restaurant_id');
             $table->string('restaurant_name');
             $table->string('restaurant_address');

--- a/database/migrations/2020_07_07_024341_create_images_table.php
+++ b/database/migrations/2020_07_07_024341_create_images_table.php
@@ -22,6 +22,9 @@ class CreateImagesTable extends Migration
             $table->foreign('post_id')
                 ->references('post_id')->on('posts')
                 ->onDelete('cascade');
+            $table->foreign('user_id')
+                ->references('user_id')->on('users')
+                ->onDelete('cascade');
         });
     }
 

--- a/database/migrations/2020_07_07_024341_create_images_table.php
+++ b/database/migrations/2020_07_07_024341_create_images_table.php
@@ -15,7 +15,8 @@ class CreateImagesTable extends Migration
     {
         Schema::create('images', function (Blueprint $table) {
             $table->bigIncrements('image_id');
-            $table->unsignedBigInteger('post_id');
+            $table->unsignedBigInteger('post_id')->nullable();
+            $table->string('user_id');
             $table->string('image_url');
             $table->string('dish_name');
             $table->foreign('post_id')

--- a/database/seeds/UserImageSeeder.php
+++ b/database/seeds/UserImageSeeder.php
@@ -1,0 +1,20 @@
+<?php
+
+use App\User;
+use App\Image;
+use Illuminate\Database\Seeder;
+
+class UserImageSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        factory(User::class, 2)->create()->each(function ($user) {
+            $user->image()->saveMany(factory(Image::class, 2)->make());
+        });
+    }
+}

--- a/database/seeds/e2e/ImageSeeder.php
+++ b/database/seeds/e2e/ImageSeeder.php
@@ -11,7 +11,7 @@ class ImageSeeder extends Seeder
         $posts = Post::all();
         $posts->each(function ($post) {
             $post->image()->createMany(
-                factory(Image::class, 2)->make()->toArray()
+                factory(Image::class, 2)->make(['user_id' => $post->user_id])->toArray()
             );
         });
     }

--- a/routes/api.php
+++ b/routes/api.php
@@ -23,4 +23,5 @@ Route::group(['prefix' => 'auth'], function ($router) {
 Route::get('/home_timeline', 'TimelineController@homeTimeline');
 Route::get('/user_timeline', 'TimelineController@userTimeline');
 
+Route::post('/post', 'PostController@storePost');
 Route::post('/image', 'PostController@storeImage');

--- a/routes/api.php
+++ b/routes/api.php
@@ -22,3 +22,5 @@ Route::group(['prefix' => 'auth'], function ($router) {
 
 Route::get('/home_timeline', 'TimelineController@homeTimeline');
 Route::get('/user_timeline', 'TimelineController@userTimeline');
+
+Route::post('/image', 'PostController@storeImage');

--- a/tests/Feature/StoreImageTest.php
+++ b/tests/Feature/StoreImageTest.php
@@ -24,33 +24,39 @@ class StoreImageTest extends TestCase
     /** @test */
     public function itSavesUploadedImage()
     {
+        $user = User::first();
         $file = UploadedFile::fake()->image('sample.jpg');
-        $response = $this->postJson('/api/image', [
+        $response = $this->actingAs($user)->postJson('/api/image', [
             'image' => $file
         ]);
 
         $response->assertCreated();
         $response->assertJsonStructure(['image_id']);
-        $this->assertEquals(Image::count(), 1);
+
+        $image = Image::all();
+        $this->assertEquals($image->count(), 1);
+        $this->assertEquals($image[0]->user_id, $user->user_id);
         Storage::disk('local')->assertExists('public/' . $file->hashName());
     }
 
     /** @test */
     public function itAllowsOnlyJPEGAndPNGFile()
     {
+        $user = User::first();
+
         $jpeg = UploadedFile::fake()->image('sample.jpeg');
         $png = UploadedFile::fake()->image('sample.png');
         $gif = UploadedFile::fake()->image('sample.gif');
 
-        $this->postJson('/api/image', [
+        $this->actingAs($user)->postJson('/api/image', [
             'image' => $jpeg
         ])->assertCreated();
 
-        $this->postJson('/api/image', [
+        $this->actingAs($user)->postJson('/api/image', [
             'image' => $png
         ])->assertCreated();
 
-        $this->postJson('/api/image', [
+        $this->actingAs($user)->postJson('/api/image', [
             'image' => $gif
         ])->assertJsonValidationErrors(['image']);
     }

--- a/tests/Feature/StoreImageTest.php
+++ b/tests/Feature/StoreImageTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Image;
+use App\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+class StoreImageTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        factory(User::class)->create();
+        Storage::fake('local');
+    }
+    
+    /** @test */
+    public function itSavesUploadedImage()
+    {
+        $file = UploadedFile::fake()->image('sample.jpg');
+        $response = $this->postJson('/api/image', [
+            'image' => $file
+        ]);
+
+        $response->assertCreated();
+        $response->assertJsonStructure(['image_id']);
+        $this->assertEquals(Image::count(), 1);
+        Storage::disk('local')->assertExists('public/' . $file->hashName());
+    }
+
+    /** @test */
+    public function itAllowsOnlyJPEGAndPNGFile()
+    {
+        $jpeg = UploadedFile::fake()->image('sample.jpeg');
+        $png = UploadedFile::fake()->image('sample.png');
+        $gif = UploadedFile::fake()->image('sample.gif');
+
+        $this->postJson('/api/image', [
+            'image' => $jpeg
+        ])->assertCreated();
+
+        $this->postJson('/api/image', [
+            'image' => $png
+        ])->assertCreated();
+
+        $this->postJson('/api/image', [
+            'image' => $gif
+        ])->assertJsonValidationErrors(['image']);
+    }
+}

--- a/tests/Feature/StorePostTest.php
+++ b/tests/Feature/StorePostTest.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Image;
+use App\Post;
+use App\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+use UserImageSeeder;
+
+class StorePostTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed(UserImageSeeder::class);
+    }
+
+    /** @test */
+    public function itSavesPostAndLinkImages()
+    {
+        $user = User::first();
+        $imageIds = $user->image()->pluck('image_id');
+
+        $response = $this->actingAs($user)->postJson('/api/post', [
+            'content' => 'this will succeed',
+            'restaurant_id' => 'idOfARestaurant',
+            'image_ids' => $imageIds
+        ]);
+
+        $response->assertCreated();
+
+        $post = Post::all();
+        $this->assertEquals($post->count(), 1);
+        $this->assertEquals($post[0]->user_id, $user->user_id);
+
+        Image::find($imageIds)->each(function ($image) use ($post) {
+            $this->assertEquals($image->post_id, $post[0]->post_id);
+        });
+    }
+
+    /** @test */
+    public function itAcceptOnlyImagesOfAuthenticatedUser()
+    {
+        $users = User::all();
+        $user = $users[0];
+        $other = $users[1];
+
+        $imageIdsOfOther = $other->image()->pluck('image_id');
+
+        $response = $this->actingAs($user)->postJson('/api/post', [
+            'content' => 'this will fail',
+            'restaurant_id' => 'idOfARestaurant',
+            'image_ids' => $imageIdsOfOther
+        ]);
+
+        $response->assertForbidden();
+    }
+
+    /** @test */
+    public function itDoesNotAcceptImagesAlreadyBelongToPost()
+    {
+        $user = User::first();
+
+        $post = $user->post()->save(factory(Post::class)->make());
+        $image = $user->image[0];
+        $image->post_id = $post->post_id;
+        $user->image[0]->save();
+
+        $response = $this->actingAs($user)->postJson('/api/post', [
+            'content' => 'this will fail',
+            'restaurant_id' => 'idOfARestaurant',
+            'image_ids' => [$image->image_id]
+        ]);
+
+        $response->assertForbidden();
+    }
+
+    /** @test */
+    public function itAcceptOnlyImagesThatExist()
+    {
+        $user = User::first();
+
+        $response = $this->actingAs($user)->postJson('/api/post', [
+            'content' => 'this will fail',
+            'restaurant_id' => 'idOfARestaurant',
+            'image_ids' => [1000]
+        ]);
+
+        $response->assertStatus(422);
+    }
+}


### PR DESCRIPTION
## 概要
新規投稿の処理を書いた
## 背景
新しい投稿をする際、画像を1枚ずつアップロードしてから投稿内容とアップロードした画像のidを新規投稿作成のエンドポイント送る流れにしたい。
## 変更内容
### 修正
* Imageモデルのincrementingがなぜかfalseになっていたので修正

### 変更
* 先に画像を登録すると投稿作成時に画像へのアクセス制御のが必要になるのでimages表にuser_id列を追加
* ImageとUserモデルの間にリレーションを設定

### 追加
* 画像保存のコントローラーメソッドとリクエストフォームクラスを作成
* 画像保存のテストを作成
* 投稿保存のコントローラーメソッドとリクエストフォームクラスを作成、あわせてPost, Imageモデルにそれぞれ必要なメソッドを追加
* 画像へのアクセス制御のためのゲートを追記
* 投稿保存のテストを作成