### PR TITLE
[Fix] 1対多のリレーションメソッド名を複数形に変更

### DIFF
--- a/app/Follow.php
+++ b/app/Follow.php
@@ -19,7 +19,7 @@ class Follow extends Model
         return $this->belongsTo(User::class, 'follow_user_id');
     }
     
-    public function post_of_follow_user()
+    public function posts_of_follow_user()
     {
         return $this->hasMany(Post::class, 'user_id', 'follow_user_id');
     }

--- a/app/Post.php
+++ b/app/Post.php
@@ -37,7 +37,7 @@ class Post extends Model
 
     public function scopeWithGoodedByUser($postQuery, $user_id)
     {
-        $postQuery->with(['good' => function ($goodQuery) use ($user_id) {
+        $postQuery->with(['goods' => function ($goodQuery) use ($user_id) {
             $goodQuery->where('user_id', $user_id);
         }]);
     }
@@ -61,17 +61,17 @@ class Post extends Model
         return $this->belongsTo(User::class, 'user_id');
     }
     
-    public function thread()
+    public function threads()
     {
         return $this->hasMany(Thread::class, 'post_id');
     }
 
-    public function good()
+    public function goods()
     {
         return $this->hasMany(Good::class, 'post_id');
     }
     
-    public function image()
+    public function images()
     {
         return $this->hasMany(Image::class, 'post_id');
     }

--- a/app/Sex.php
+++ b/app/Sex.php
@@ -9,7 +9,7 @@ class Sex extends Model
     protected $primaryKey = 'sex_id';
     public $timestamps = false;
     
-    public function user()
+    public function users()
     {
         return $this->hasMany(User::class, 'sex_id');
     }

--- a/app/Thread.php
+++ b/app/Thread.php
@@ -17,7 +17,7 @@ class Thread extends Model
         return $this->belongsTo(Post::class, 'post_id');
     }
 
-    public function comment()
+    public function comments()
     {
         return $this->hasMany(Comment::class, 'thread_id');
     }

--- a/app/User.php
+++ b/app/User.php
@@ -19,7 +19,7 @@ class User extends Authenticatable implements JWTSubject
     public function homeTimeline($sinceId = null, $untilId = null, $count = null)
     {
         return $this->getPosts($sinceId, $untilId, $count, function ($query) {
-            $query->whereIn('user_id', $this->following()->pluck('follow_user_id'));
+            $query->whereIn('user_id', $this->followings()->pluck('follow_user_id'));
         });
     }
 
@@ -34,7 +34,7 @@ class User extends Authenticatable implements JWTSubject
     {
         $query = Post::getBetween($sinceId, $untilId, $count)
             ->withGoodedByUser($this->user_id)
-            ->with('image')
+            ->with('images')
             ->with('user');
 
         $callable && $callable($query);
@@ -57,37 +57,37 @@ class User extends Authenticatable implements JWTSubject
         return $this->belongsTo(Sex::class, 'sex_id');
     }
 
-    public function post()
+    public function posts()
     {
         return $this->hasMany(Post::class, 'user_id');
     }
 
-    public function good()
+    public function goods()
     {
         return $this->hasMany(Good::class, 'user_id');
     }
 
-    public function following()
+    public function followings()
     {
         return $this->hasMany(Follow::class, 'user_id');
     }
 
-    public function followed()
+    public function followeds()
     {
         return $this->hasMany(Follow::class, 'follow_user_id');
     }
 
-    public function comment()
+    public function comments()
     {
         return $this->hasMany(Comment::class, 'user_id');
     }
 
-    public function to_go()
+    public function to_goes()
     {
         return $this->hasMany(ToGo::class, 'user_id');
     }
     
-    public function image()
+    public function images()
     {
         return $this->hasMany(Image::class, 'user_id');
     }

--- a/database/seeds/e2e/CommentSeeder.php
+++ b/database/seeds/e2e/CommentSeeder.php
@@ -13,8 +13,6 @@ class CommentSeeder extends Seeder
         $threads = Thread::all();
         $users = User::all();
         $threads->each(function ($thread) use ($users) {
-            $commentingUsers = $users->random(2)->shuffle();
-            
             $comments = $users->random(2)->map(function ($user) use ($thread) {
                 return $thread->comments()->save(
                     factory(Comment::class)->make(['user_id' => $user->user_id])

--- a/database/seeds/e2e/CommentSeeder.php
+++ b/database/seeds/e2e/CommentSeeder.php
@@ -16,7 +16,7 @@ class CommentSeeder extends Seeder
             $commentingUsers = $users->random(2)->shuffle();
             
             $comments = $users->random(2)->map(function ($user) use ($thread) {
-                return $thread->comment()->save(
+                return $thread->comments()->save(
                     factory(Comment::class)->make(['user_id' => $user->user_id])
                 );
             });

--- a/database/seeds/e2e/FollowSeeder.php
+++ b/database/seeds/e2e/FollowSeeder.php
@@ -14,7 +14,7 @@ class FollowSeeder extends Seeder
             $followings = $users->except([$user->user_id])->random(4);
 
             $followings->each(function ($following) use ($user) {
-                $user->following()->save(
+                $user->followings()->save(
                     factory(Follow::class)->make(
                         [
                         'follow_user_id' => $following->user_id

--- a/database/seeds/e2e/FollowSeeder.php
+++ b/database/seeds/e2e/FollowSeeder.php
@@ -17,8 +17,8 @@ class FollowSeeder extends Seeder
                 $user->followings()->save(
                     factory(Follow::class)->make(
                         [
-                        'follow_user_id' => $following->user_id
-                    ]
+                            'follow_user_id' => $following->user_id
+                        ]
                     )
                 );
             });

--- a/database/seeds/e2e/GoodSeeder.php
+++ b/database/seeds/e2e/GoodSeeder.php
@@ -16,9 +16,6 @@ class GoodSeeder extends Seeder
 
             $timeline = Post::wherein('user_id', $follow_user_ids)->get();
             $timeline->random(10)->each(function ($post) use ($user) {
-                // $post->good()->save(
-                //     factory(Good::class)->make([ 'user_id' => $user->user_id ])
-                // );
                 Good::create([
                     'user_id' => $user->user_id,
                     'post_id' => $post->post_id

--- a/database/seeds/e2e/GoodSeeder.php
+++ b/database/seeds/e2e/GoodSeeder.php
@@ -9,10 +9,10 @@ class GoodSeeder extends Seeder
 {
     public function run()
     {
-        $users = User::with('following')->get();
+        $users = User::with('followings')->get();
 
         $users->each(function ($user) {
-            $follow_user_ids = $user->following->pluck('follow_user_id');
+            $follow_user_ids = $user->followings->pluck('follow_user_id');
 
             $timeline = Post::wherein('user_id', $follow_user_ids)->get();
             $timeline->random(10)->each(function ($post) use ($user) {

--- a/database/seeds/e2e/ImageSeeder.php
+++ b/database/seeds/e2e/ImageSeeder.php
@@ -10,7 +10,7 @@ class ImageSeeder extends Seeder
     {
         $posts = Post::all();
         $posts->each(function ($post) {
-            $post->image()->createMany(
+            $post->images()->createMany(
                 factory(Image::class, 2)->make(['user_id' => $post->user_id])->toArray()
             );
         });

--- a/database/seeds/e2e/PostSeeder.php
+++ b/database/seeds/e2e/PostSeeder.php
@@ -10,7 +10,7 @@ class PostSeeder extends Seeder
     {
         $users = User::all();
         $users->each(function ($user) {
-            $user->post()->createMany(
+            $user->posts()->createMany(
                 factory(Post::class, 5)->make()->toArray()
             );
         });

--- a/database/seeds/e2e/ThreadSeeder.php
+++ b/database/seeds/e2e/ThreadSeeder.php
@@ -9,11 +9,11 @@ class ThreadSeeder extends Seeder
 {
     public function run()
     {
-        $users = User::with('post')->get();
+        $users = User::with('posts')->get();
 
         $users->each(function ($user) {
-            $user->post->random(3)->each(function ($post) {
-                $post->thread()->createMany(
+            $user->posts->random(3)->each(function ($post) {
+                $post->threads()->createMany(
                     factory(Thread::class, 2)->make()->toArray()
                 );
             });

--- a/database/seeds/unit/UserImageSeeder.php
+++ b/database/seeds/unit/UserImageSeeder.php
@@ -14,7 +14,7 @@ class UserImageSeeder extends Seeder
     public function run()
     {
         factory(User::class, 2)->create()->each(function ($user) {
-            $user->image()->saveMany(factory(Image::class, 2)->make());
+            $user->images()->saveMany(factory(Image::class, 2)->make());
         });
     }
 }

--- a/database/seeds/unit/UserPostSeeder.php
+++ b/database/seeds/unit/UserPostSeeder.php
@@ -12,7 +12,7 @@ class UserPostSeeder extends Seeder
     {
         $users = factory(User::class, 3)->create();
         $users->each(function ($user) {
-            $user->post()->saveMany(factory(Post::class, 3)->make());
+            $user->posts()->saveMany(factory(Post::class, 3)->make());
         });
     }
 }

--- a/tests/Feature/StorePostTest.php
+++ b/tests/Feature/StorePostTest.php
@@ -24,7 +24,7 @@ class StorePostTest extends TestCase
     public function itSavesPostAndLinkImages()
     {
         $user = User::first();
-        $imageIds = $user->image()->pluck('image_id');
+        $imageIds = $user->images()->pluck('image_id');
 
         $response = $this->actingAs($user)->postJson('/api/post', [
             'content' => 'this will succeed',
@@ -50,7 +50,7 @@ class StorePostTest extends TestCase
         $user = $users[0];
         $other = $users[1];
 
-        $imageIdsOfOther = $other->image()->pluck('image_id');
+        $imageIdsOfOther = $other->images()->pluck('image_id');
 
         $response = $this->actingAs($user)->postJson('/api/post', [
             'content' => 'this will fail',
@@ -66,10 +66,10 @@ class StorePostTest extends TestCase
     {
         $user = User::first();
 
-        $post = $user->post()->save(factory(Post::class)->make());
-        $image = $user->image[0];
+        $post = $user->posts()->save(factory(Post::class)->make());
+        $image = $user->images[0];
         $image->post_id = $post->post_id;
-        $user->image[0]->save();
+        $image->save();
 
         $response = $this->actingAs($user)->postJson('/api/post', [
             'content' => 'this will fail',

--- a/tests/Unit/PostTest.php
+++ b/tests/Unit/PostTest.php
@@ -50,13 +50,13 @@ class PostTest extends TestCase
         $post = Post::first();
 
         $post = Post::withGoodedByUser($user->user_id)->find($post->getKey());
-        $this->assertTrue($post->relationLoaded('good'));
-        $this->assertTrue($post->good->isEmpty());
+        $this->assertTrue($post->relationLoaded('goods'));
+        $this->assertTrue($post->goods->isEmpty());
 
-        $post->good()->save(factory(Good::class)->make(['user_id' => $user->user_id]));
-        $post->good()->save(factory(Good::class)->make(['user_id' => $other->user_id]));
+        $post->goods()->save(factory(Good::class)->make(['user_id' => $user->user_id]));
+        $post->goods()->save(factory(Good::class)->make(['user_id' => $other->user_id]));
 
         $post = Post::withGoodedByUser($user->user_id)->find($post->getKey());
-        $this->assertEquals(1, $post->good->count());
+        $this->assertEquals(1, $post->goods->count());
     }
 }

--- a/tests/Unit/UserTest.php
+++ b/tests/Unit/UserTest.php
@@ -26,7 +26,7 @@ class UserTest extends TestCase
 
         $this->assertEmpty($users[0]->homeTimeline()->toArray());
 
-        $users[0]->following()->save(
+        $users[0]->followings()->save(
             factory(Follow::class)->make(['follow_user_id' => $users[1]->user_id])
         );
 
@@ -59,8 +59,8 @@ class UserTest extends TestCase
         $user = User::first();
 
         $post = $user->getPosts(null, null, null)[0];
-        $this->assertTrue($post->relationLoaded('good'));
-        $this->assertTrue($post->relationLoaded('image'));
+        $this->assertTrue($post->relationLoaded('goods'));
+        $this->assertTrue($post->relationLoaded('images'));
         $this->assertTrue($post->relationLoaded('user'));
     }
 }


### PR DESCRIPTION
## 変更内容
### メイン
モデルのhasManyのリレーションメソッド名が単数形になっていてわかりにくかったので複数形に変更

### ついでにやってしまったこと
UserImageSeederのがseeds直下にあったのでunitフォルダに移動
シーダーにいらないコードがあっりしたので整頓