### PR TITLE
[Add] スレッドとコメントの作成、取得、削除

### DIFF
--- a/app/Comment.php
+++ b/app/Comment.php
@@ -16,4 +16,9 @@ class Comment extends Model
     {
         return $this->belongsTo(Thread::class, 'thread_id');
     }
+
+    public function user()
+    {
+        return $this->belongsTo(User::class, 'user_id');
+    }
 }

--- a/app/Comment.php
+++ b/app/Comment.php
@@ -10,6 +10,7 @@ class Comment extends Model
     use SoftDeletes;
 
     protected $primaryKey = 'comment_id';
+    protected $guarded = [];
 
     public function thread()
     {

--- a/app/Http/Controllers/CommentController.php
+++ b/app/Http/Controllers/CommentController.php
@@ -2,7 +2,9 @@
 
 namespace App\Http\Controllers;
 
+use App\Http\Requests\StoreChildComment;
 use App\Http\Requests\StoreParentComment;
+use App\Comment;
 use App\Thread;
 use Auth;
 use DB;
@@ -25,5 +27,11 @@ class CommentController extends Controller
                 'user_id' => Auth::id()
             ]);
         });
+    }
+
+    public function storeChildComment(storeChildComment $request)
+    {
+        $attributes = array_merge($request->validated(), ['user_id' => Auth::id()]);
+        return Comment::create($attributes);
     }
 }

--- a/app/Http/Controllers/CommentController.php
+++ b/app/Http/Controllers/CommentController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Http\Requests\StoreChildComment;
 use App\Http\Requests\StoreParentComment;
 use App\Comment;
+use App\Post;
 use App\Thread;
 use Auth;
 use DB;
@@ -29,20 +30,24 @@ class CommentController extends Controller
         });
     }
 
-    public function deleteParentComment(Comment $comment)
-    {
-        $this->authorize('delete-comment', $comment);
-
-        $thread = Thread::where('comment_id', $comment->comment_id)->first();
-        abort_unless($thread, 422, 'specified comment is not a parent comment');
-
-        $thread->delete();
-        return response()->json(['message' => 'OK'], 200);
-    }
-
     public function storeChildComment(storeChildComment $request)
     {
         $attributes = array_merge($request->validated(), ['user_id' => Auth::id()]);
         return Comment::create($attributes);
+    }
+    
+    public function delete(Comment $comment)
+    {
+        $this->authorize('delete-comment', $comment);
+
+        $thread = Thread::where('comment_id', $comment->comment_id)->first();
+
+        if ($thread) {
+            $thread->delete();
+        } else {
+            $comment->delete();
+        }
+
+        return response()->json(['message' => 'OK'], 200);
     }
 }

--- a/app/Http/Controllers/CommentController.php
+++ b/app/Http/Controllers/CommentController.php
@@ -5,7 +5,6 @@ namespace App\Http\Controllers;
 use App\Http\Requests\StoreChildComment;
 use App\Http\Requests\StoreParentComment;
 use App\Comment;
-use App\Post;
 use App\Thread;
 use Auth;
 use DB;
@@ -16,6 +15,22 @@ class CommentController extends Controller
     public function __construct()
     {
         $this->middleware('auth');
+    }
+
+    public function index(Request $request)
+    {
+        $request->validate(['post_id' => 'required|integer']);
+
+        $commentIds = Thread::where('post_id', $request->post_id)->pluck('comment_id');
+
+        return Comment::whereIn('comment_id', $commentIds)->paginate(20);
+    }
+
+    public function show(Request $request)
+    {
+        $requset->validate(['thread_id' => 'required|integer']);
+
+        return Comment::where('thread_id', $requset->thread_id)->paginate(20);
     }
 
     public function storeParentComment(storeParentComment $request)

--- a/app/Http/Controllers/CommentController.php
+++ b/app/Http/Controllers/CommentController.php
@@ -23,14 +23,14 @@ class CommentController extends Controller
 
         $commentIds = Thread::where('post_id', $request->post_id)->pluck('comment_id');
 
-        return Comment::whereIn('comment_id', $commentIds)->paginate(20);
+        return Comment::with('user')->whereIn('comment_id', $commentIds)->paginate(20);
     }
 
     public function show(Request $request)
     {
-        $requset->validate(['thread_id' => 'required|integer']);
+        $request->validate(['thread_id' => 'required|integer']);
 
-        return Comment::where('thread_id', $requset->thread_id)->paginate(20);
+        return Comment::with('user')->where('thread_id', $request->thread_id)->paginate(20);
     }
 
     public function storeParentComment(storeParentComment $request)

--- a/app/Http/Controllers/CommentController.php
+++ b/app/Http/Controllers/CommentController.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\StoreParentComment;
+use App\Thread;
+use Auth;
+use DB;
+use Illuminate\Http\Request;
+
+class CommentController extends Controller
+{
+    public function __construct()
+    {
+        $this->middleware('auth');
+    }
+
+    public function storeParentComment(storeParentComment $request)
+    {
+        return DB::transaction(function () {
+            $thread = Thread::create(['post_id' => request('post_id')]);
+
+            return $thread->createParentComment([
+                'comment' => request('comment'),
+                'user_id' => Auth::id()
+            ]);
+        });
+    }
+}

--- a/app/Http/Controllers/CommentController.php
+++ b/app/Http/Controllers/CommentController.php
@@ -29,6 +29,17 @@ class CommentController extends Controller
         });
     }
 
+    public function deleteParentComment(Comment $comment)
+    {
+        $this->authorize('delete-comment', $comment);
+
+        $thread = Thread::where('comment_id', $comment->comment_id)->first();
+        abort_unless($thread, 422, 'specified comment is not a parent comment');
+
+        $thread->delete();
+        return response()->json(['message' => 'OK'], 200);
+    }
+
     public function storeChildComment(storeChildComment $request)
     {
         $attributes = array_merge($request->validated(), ['user_id' => Auth::id()]);

--- a/app/Http/Controllers/CommentController.php
+++ b/app/Http/Controllers/CommentController.php
@@ -51,7 +51,7 @@ class CommentController extends Controller
         return Comment::create($attributes);
     }
     
-    public function delete(Comment $comment)
+    public function destroy(Comment $comment)
     {
         $this->authorize('delete-comment', $comment);
 

--- a/app/Http/Requests/StoreChildComment.php
+++ b/app/Http/Requests/StoreChildComment.php
@@ -25,7 +25,7 @@ class StoreChildComment extends FormRequest
     {
         return [
             'comment' => 'required',
-            'thread_id' => 'required|integer'
+            'thread_id' => 'required|integer|exists:threads,thread_id'
         ];
     }
 }

--- a/app/Http/Requests/StoreChildComment.php
+++ b/app/Http/Requests/StoreChildComment.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreChildComment extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'comment' => 'required',
+            'thread_id' => 'required|integer'
+        ];
+    }
+}

--- a/app/Http/Requests/StoreParentComment.php
+++ b/app/Http/Requests/StoreParentComment.php
@@ -25,7 +25,7 @@ class StoreParentComment extends FormRequest
     {
         return [
            'comment' => 'required',
-           'post_id' => 'required|integer'
+           'post_id' => 'required|integer|exists:posts,post_id'
         ];
     }
 }

--- a/app/Http/Requests/StoreParentComment.php
+++ b/app/Http/Requests/StoreParentComment.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreParentComment extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+           'comment' => 'required',
+           'post_id' => 'required|integer'
+        ];
+    }
+}

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -28,5 +28,9 @@ class AuthServiceProvider extends ServiceProvider
         Gate::define('link_image', function ($user, $image) {
             return $image->post_id === null && $user->user_id === $image->user_id;
         });
+
+        Gate::define('delete-comment', function ($user, $comment) {
+            return $user->user_id === $comment->user_id;
+        });
     }
 }

--- a/app/Thread.php
+++ b/app/Thread.php
@@ -10,6 +10,7 @@ class Thread extends Model
     use SoftDeletes;
     
     protected $primaryKey = 'thread_id';
+    protected $guarded = [];
     public $timestamps = false;
 
     public function post()
@@ -20,5 +21,18 @@ class Thread extends Model
     public function comments()
     {
         return $this->hasMany(Comment::class, 'thread_id');
+    }
+
+    public function createParentComment($commentAttributes)
+    {
+        $comment = $this->comments()->create($commentAttributes);
+        $this->linkComment($comment->comment_id);
+        return $comment;
+    }
+
+    public function linkComment($comment_id)
+    {
+        $this->comment_id = $comment_id;
+        $this->save();
     }
 }

--- a/app/Thread.php
+++ b/app/Thread.php
@@ -35,4 +35,13 @@ class Thread extends Model
         $this->comment_id = $comment_id;
         $this->save();
     }
+
+    protected static function boot()
+    {
+        parent::boot();
+
+        static::deleting(function ($thread) {
+            $thread->comments()->delete();
+        });
+    }
 }

--- a/app/User.php
+++ b/app/User.php
@@ -14,6 +14,12 @@ class User extends Authenticatable implements JWTSubject
     
     protected $primaryKey = 'user_id';
     protected $keyType = 'string';
+    protected $hidden = [
+        'password',
+        'password_reset_token',
+        'token_expires_at',
+        'password_updated_at'
+    ];
     public $incrementing = false;
 
     public function homeTimeline($sinceId = null, $untilId = null, $count = null)

--- a/database/seeds/unit/ThreadCommentSeeder.php
+++ b/database/seeds/unit/ThreadCommentSeeder.php
@@ -1,0 +1,30 @@
+<?php
+
+use App\Comment;
+use App\Post;
+use App\Thread;
+use App\User;
+use Illuminate\Database\Seeder;
+
+class ThreadCommentSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        $user = factory(User::class)->create();
+        $post = $user->posts()->save(factory(Post::class)->make());
+
+        $threads = $post->threads()->saveMany(factory(Thread::class, 3)->make());
+
+        $threads->each(function ($thread) use ($user) {
+            $comment = $thread->comments()->saveMany(factory(Comment::class, 3)->make(['user_id' => $user->user_id]));
+            
+            $thread->comment_id = $comment[0]->comment_id;
+            $thread->save();
+        });
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -27,4 +27,4 @@ Route::post('/post', 'PostController@storePost');
 Route::post('/image', 'PostController@storeImage');
 Route::post('/comment/parent', 'CommentController@storeParentComment');
 Route::post('/comment/child', 'CommentController@storeChildComment');
-Route::get('/comment/parent/{comment}', 'CommentController@deleteParentComment');
+Route::delete('/comment/{comment}', 'CommentController@delete');

--- a/routes/api.php
+++ b/routes/api.php
@@ -26,3 +26,4 @@ Route::get('/user_timeline', 'TimelineController@userTimeline');
 Route::post('/post', 'PostController@storePost');
 Route::post('/image', 'PostController@storeImage');
 Route::post('/comment/parent', 'CommentController@storeParentComment');
+Route::post('/comment/child', 'CommentController@storeChildComment');

--- a/routes/api.php
+++ b/routes/api.php
@@ -28,3 +28,5 @@ Route::post('/image', 'PostController@storeImage');
 Route::post('/comment/parent', 'CommentController@storeParentComment');
 Route::post('/comment/child', 'CommentController@storeChildComment');
 Route::delete('/comment/{comment}', 'CommentController@delete');
+Route::get('/comment/parent', 'CommentController@index');
+Route::get('/comment/child', 'CommentController@show');

--- a/routes/api.php
+++ b/routes/api.php
@@ -27,6 +27,6 @@ Route::post('/post', 'PostController@storePost');
 Route::post('/image', 'PostController@storeImage');
 Route::post('/comment/parent', 'CommentController@storeParentComment');
 Route::post('/comment/child', 'CommentController@storeChildComment');
-Route::delete('/comment/{comment}', 'CommentController@delete');
+Route::delete('/comment/{comment}', 'CommentController@destroy');
 Route::get('/comment/parent', 'CommentController@index');
 Route::get('/comment/child', 'CommentController@show');

--- a/routes/api.php
+++ b/routes/api.php
@@ -25,3 +25,4 @@ Route::get('/user_timeline', 'TimelineController@userTimeline');
 
 Route::post('/post', 'PostController@storePost');
 Route::post('/image', 'PostController@storeImage');
+Route::post('/comment/parent', 'CommentController@storeParentComment');

--- a/routes/api.php
+++ b/routes/api.php
@@ -27,3 +27,4 @@ Route::post('/post', 'PostController@storePost');
 Route::post('/image', 'PostController@storeImage');
 Route::post('/comment/parent', 'CommentController@storeParentComment');
 Route::post('/comment/child', 'CommentController@storeChildComment');
+Route::get('/comment/parent/{comment}', 'CommentController@deleteParentComment');

--- a/tests/Feature/ChildCommentTest.php
+++ b/tests/Feature/ChildCommentTest.php
@@ -22,19 +22,20 @@ class ChildCommentTest extends TestCase
         $thread = factory(Thread::class)->create([
             'post_id' => Post::first()->post_id
         ]);
-
+        
         $response = $this->actingAs($user)->postJson('/api/comment/child', [
             'comment' => 'hello world',
             'thread_id' => $thread->thread_id
         ]);
 
         $response->assertCreated();
-        
         $this->assertEquals(1, $thread->comments->count());
 
-        $comment = $thread->comments[0];
-        $this->assertEquals($user->user_id, $comment->user_id);
-        $this->assertEquals('hello world', $comment->comment);
+        $this->assertDatabaseHas('comments', [
+            'comment' => 'hello world',
+            'user_id' => $user->user_id,
+            'thread_id' => $thread->thread_id
+        ]);
     }
 
     /** @test */

--- a/tests/Feature/ChildCommentTest.php
+++ b/tests/Feature/ChildCommentTest.php
@@ -36,4 +36,18 @@ class ChildCommentTest extends TestCase
         $this->assertEquals($user->user_id, $comment->user_id);
         $this->assertEquals('hello world', $comment->comment);
     }
+
+    /** @test */
+    public function itValidatesIfThreadExistsWhenCreatingComment()
+    {
+        $user = factory(User::class)->create();
+        
+        $response = $this->actingAs($user)->postJson('/api/comment/child', [
+            'comment' => 'thread not exists',
+            'thread_id' => 1234
+        ]);
+
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors(['thread_id']);
+    }
 }

--- a/tests/Feature/ChildCommentTest.php
+++ b/tests/Feature/ChildCommentTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Post;
+use App\Thread;
+use App\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+use UserPostSeeder;
+
+class ChildCommentTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    public function itSavesComment()
+    {
+        $this->seed(UserPostSeeder::class);
+        $user = User::first();
+        $thread = factory(Thread::class)->create([
+            'post_id' => Post::first()->post_id
+        ]);
+
+        $response = $this->actingAs($user)->postJson('/api/comment/child', [
+            'comment' => 'hello world',
+            'thread_id' => $thread->thread_id
+        ]);
+
+        $response->assertCreated();
+        
+        $this->assertEquals(1, $thread->comments->count());
+
+        $comment = $thread->comments[0];
+        $this->assertEquals($user->user_id, $comment->user_id);
+        $this->assertEquals('hello world', $comment->comment);
+    }
+}

--- a/tests/Feature/DeleteCommentTest.php
+++ b/tests/Feature/DeleteCommentTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Comment;
+use App\Thread;
+use App\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+use ThreadCommentSeeder;
+
+class DeleteCommentTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    public function itDeletesComment()
+    {
+        $this->seed(ThreadCommentSeeder::class);
+        $thread = Thread::first();
+        $comment = $thread->comments[1];
+
+        $response = $this->actingAs(User::first())
+            ->deleteJson('/api/comment/' . $comment->comment_id);
+
+        $response->assertOk();
+        $this->assertSoftDeleted($comment);
+        $this->assertTrue($thread->is(Thread::first()));
+    }
+    
+    /** @test */
+    public function itDeletesEntireThreadWhenParentCommentDeleted()
+    {
+        $this->seed(ThreadCommentSeeder::class);
+        $thread = Thread::first();
+
+        $response = $this->actingAs(User::first())
+            ->deleteJson('/api/comment/' . $thread->comment_id);
+    
+        $response->assertOk();
+        $this->assertSoftDeleted($thread);
+        $this->assertTrue($thread->comments->isEmpty());
+    }
+
+    /** @test */
+    public function itReturns403WhenCommentNotBelongToUser()
+    {
+        $this->seed(ThreadCommentSeeder::class);
+        $user = factory(User::class)->create();
+        $comment = Comment::first();
+
+        $response = $this->actingAs($user)
+            ->deleteJson('/api/comment/' . $comment->comment_id);
+
+        $response->assertForbidden();
+    }
+}

--- a/tests/Feature/ParentCommentTest.php
+++ b/tests/Feature/ParentCommentTest.php
@@ -22,21 +22,22 @@ class ParentCommentTest extends TestCase
         $user = User::first();
         $post = Post::first();
 
-        $commentContent = 'random comment';
         $response = $this->actingAs($user)->postJson('/api/comment/parent', [
             'post_id' => $post->post_id,
-            'comment' => $commentContent
+            'comment' => 'hello world'
         ]);
 
         $response->assertStatus(201);
         
         $thread = Thread::all();
-        $this->assertEquals($thread->count(), 1);
-        $this->assertEquals($thread[0]->post_id, $post->post_id);
+        $this->assertEquals(1, $thread->count());
+        $this->assertEquals($post->post_id, $thread[0]->post_id);
+
+        $this->assertEquals(1, Comment::count());
 
         $comment = Comment::find($thread[0]->comment_id);
-        $this->assertEquals($comment->user_id, $user->user_id);
-        $this->assertEquals($comment->comment, $commentContent);
+        $this->assertEquals($user->user_id, $comment->user_id);
+        $this->assertEquals('hello world', $comment->comment);
     }
 
     /** @test */

--- a/tests/Feature/ParentCommentTest.php
+++ b/tests/Feature/ParentCommentTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Comment;
+use App\Post;
+use App\Thread;
+use App\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use UserPostSeeder;
+use Tests\TestCase;
+
+class ParentCommentTest extends TestCase
+{
+    use RefreshDatabase;
+    
+    /** @test */
+    public function itSavesThreadsAndComment()
+    {
+        $this->seed(UserPostSeeder::class);
+        $user = User::first();
+        $post = Post::first();
+
+        $commentContent = 'random comment';
+        $response = $this->actingAs($user)->postJson('/api/comment/parent', [
+            'post_id' => $post->post_id,
+            'comment' => $commentContent
+        ]);
+
+        $response->assertStatus(201);
+        
+        $thread = Thread::all();
+        $this->assertEquals($thread->count(), 1);
+        $this->assertEquals($thread[0]->post_id, $post->post_id);
+
+        $comment = Comment::find($thread[0]->comment_id);
+        $this->assertEquals($comment->user_id, $user->user_id);
+        $this->assertEquals($comment->comment, $commentContent);
+    }
+}

--- a/tests/Feature/ParentCommentTest.php
+++ b/tests/Feature/ParentCommentTest.php
@@ -38,4 +38,18 @@ class ParentCommentTest extends TestCase
         $this->assertEquals($comment->user_id, $user->user_id);
         $this->assertEquals($comment->comment, $commentContent);
     }
+
+    /** @test */
+    public function itValidatesIfPostExistsWhenCreatingNewThread()
+    {
+        $user = factory(User::class)->create();
+
+        $response = $this->actingAs($user)->postJson('/api/comment/parent', [
+            'post_id' => 12345,
+            'comment' => 'post_id above does not exist'
+        ]);
+
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors(['post_id']);
+    }
 }


### PR DESCRIPTION
## 概要
スレッドとコメントの更新以外の操作ができるようにそれぞれエンドポイントを作成

## 変更内容
* 親コメント(thread + comment)と子コメント(comment)に分けてそれぞれ作成、取得の機能を作成。
* コメント削除機能を作成(親コメントだと子も道連れにして削除される)
* 取得以外のテスト作成