### PR TITLE
[Add] restaurant search before create post

### DIFF
--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -30,9 +30,9 @@ class PostController extends Controller
 
         $images = $this->verifyUserCanLinkImages($request->image_ids);
 
-        $restaurant = $this->restaurantApiService->searchRestaurant(['id' => $request->restaurant_id]);
-        $attributes['restaurant_name'] = $restaurant['rest'][0]['name'];
-        $attributes['restaurant_address'] = $restaurant['rest'][0]['address'];
+        $restaurant = $this->restaurantApiService->getRestaurant($request->restaurant_id);
+        $attributes['restaurant_name'] = $restaurant['name'];
+        $attributes['restaurant_address'] = $restaurant['address'];
 
         return Post::createAndLinkImage($attributes, $images);
     }

--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Image;
 use App\Post;
+use App\Services\GurunaviApiService;
 use App\User;
 use App\Http\Requests\StorePost;
 use App\Http\Requests\StoreImage;
@@ -13,9 +14,11 @@ use Illuminate\Support\Facades\DB;
 
 class PostController extends Controller
 {
-    public function __construct()
+    private $restaurantApiService;
+    public function __construct(GurunaviApiService $restaurantApiService)
     {
         $this->middleware('auth');
+        $this->restaurantApiService = $restaurantApiService;
     }
 
     public function storePost(StorePost $request)
@@ -25,11 +28,11 @@ class PostController extends Controller
 
         $attributes['user_id'] = Auth::id();
 
-        //restaurant_name & restaurant_addressをぐるなびAPIから取ってくる
-        $attributes['restaurant_name'] = '鳥貴族';
-        $attributes['restaurant_address'] = '〒589-0011 大阪府';
-
         $images = $this->verifyUserCanLinkImages($request->image_ids);
+
+        $restaurant = $this->restaurantApiService->searchRestaurant(['id' => $request->restaurant_id]);
+        $attributes['restaurant_name'] = $restaurant['rest'][0]['name'];
+        $attributes['restaurant_address'] = $restaurant['rest'][0]['address'];
 
         return Post::createAndLinkImage($attributes, $images);
     }

--- a/app/Services/GurunaviApiService.php
+++ b/app/Services/GurunaviApiService.php
@@ -9,10 +9,18 @@ use GuzzleHttp\Client;
 
 class GurunaviApiService
 {
-    public function searchRestaurant($params)
+    public function searchRestaurants($params)
     {
         $restSearchUrl = config('gurunavi.restSearchUrl');
         return $this->getApiData($restSearchUrl, $params);
+    }
+
+    public function getRestaurant($id)
+    {
+        $response = $this->searchRestaurants([
+            'id' => $id
+        ]);
+        return $response['rest'][0];
     }
 
     public function getAreaMaster()

--- a/tests/Feature/StorePostTest.php
+++ b/tests/Feature/StorePostTest.php
@@ -20,8 +20,8 @@ class StorePostTest extends TestCase
         parent::setUp();
         $this->seed(UserImageSeeder::class);
 
-        $this->mock(GurunaviApiService::class, function ($mock) {
-            $mock->shouldReceive('searchRestaurant')
+        $this->partialMock(GurunaviApiService::class, function ($mock) {
+            $mock->shouldReceive('searchRestaurants')
                 ->with(['id' => 'idOfARestaurant'])
                 ->andReturn([
                     'total_hit_count' => 1,


### PR DESCRIPTION
## 概要
新しい投稿作成時に実際にぐるなびのAPIからデータを取得するように変更

## 変更内容
* レストラン検索サービスに1件取得のメソッドを追加
* これまで実際にぐるなびで検索はせずにダミーデータを入れてたので、実際に検索するように変更
* 変更に合わせてテストを追記