### PR TITLE
[Fix] レストラン検索で500が返っていたバグ

### DIFF
--- a/app/Http/Controllers/RestaurantSearchController.php
+++ b/app/Http/Controllers/RestaurantSearchController.php
@@ -17,7 +17,7 @@ class RestaurantSearchController extends Controller
 
     public function search(Request $request)
     {
-        $result = $this->restaurantService->searchRestaurant($request->all());
+        $result = $this->restaurantService->searchRestaurants($request->all());
         return $result;
     }
 }


### PR DESCRIPTION
## 概要
以前のプルリク でGurunaviApiService::searchRestaurant -> searchRestaurantsに変えた際RestaurantSearchControllerを書き換え忘れていたので修正