### PR TITLE
[Add] restaurant timeline

### DIFF
--- a/app/Http/Controllers/TimelineController.php
+++ b/app/Http/Controllers/TimelineController.php
@@ -35,6 +35,14 @@ class TimelineController extends Controller
         return TimelineResource::collection($posts);
     }
 
+    public function restaurantTimeline(GetTimeline $request)
+    {
+        [$sinceId, $untilId, $count] = $this->destructLimitOptions($request);
+
+        $posts = Auth::user()->restaurantTimeline($request->restaurant_id, $sinceId, $untilId, $count);
+        return TimelineResource::collection($posts);
+    }
+
     private function destructLimitOptions()
     {
         $request = request();

--- a/app/Http/Controllers/TimelineController.php
+++ b/app/Http/Controllers/TimelineController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Http\Requests\GetTimeline;
+use App\Http\Requests\GetRestaurantTimeline;
 use App\Http\Resources\Timeline as TimelineResource;
 use App\Post;
 use Auth;
@@ -35,7 +36,7 @@ class TimelineController extends Controller
         return TimelineResource::collection($posts);
     }
 
-    public function restaurantTimeline(GetTimeline $request)
+    public function restaurantTimeline(GetRestaurantTimeline $request)
     {
         [$sinceId, $untilId, $count] = $this->destructLimitOptions($request);
 

--- a/app/Http/Requests/GetRestaurantTimeline.php
+++ b/app/Http/Requests/GetRestaurantTimeline.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class GetRestaurantTimeline extends GetTimeline
+{
+    public function authorize()
+    {
+        return true;
+    }
+
+    public function rules()
+    {
+        $rules = [
+            'restaurant_id' => 'required'
+        ];
+
+        return array_merge(parent::rules(), $rules);
+    }
+}

--- a/app/Post.php
+++ b/app/Post.php
@@ -19,7 +19,7 @@ class Post extends Model
         'like_flag' => 'bool'
     ];
 
-    public function scopeGetBetween($query, $sinceId, $untilId, $count = null)
+    public function scopeIdBetween($query, $sinceId, $untilId, $count = null)
     {
         $keyName = $this->getQualifiedKeyName();
 
@@ -55,7 +55,7 @@ class Post extends Model
     public function scopeTimeline($query, $sinceId, $untilId, $count = null, $userId = null)
     {
         $query->withTimelineRelations($userId)
-            ->getBetween($sinceId, $untilId, $count);
+            ->idBetween($sinceId, $untilId, $count);
     }
 
     public static function createAndLinkImage($attributes, $images)

--- a/app/Post.php
+++ b/app/Post.php
@@ -44,6 +44,18 @@ class Post extends Model
         }]);
     }
 
+    public static function getTimeline($sinceId, $untilId, $count, $userId = null, $callable = null)
+    {
+        $query = self::getBetween($sinceId, $untilId, $count)
+            ->with('images')
+            ->with('user');
+
+        $userId && $query->withGoodedByUser($userId);
+        $callable && $callable($query);
+
+        return $query->get();
+    }
+
     public static function createAndLinkImage($attributes, $images)
     {
         $post = static::create($attributes);

--- a/app/Post.php
+++ b/app/Post.php
@@ -44,16 +44,18 @@ class Post extends Model
         }]);
     }
 
-    public static function getTimeline($sinceId, $untilId, $count, $userId = null, $callable = null)
+    public function scopeWithTimelineRelations($query, $userId = null)
     {
-        $query = self::getBetween($sinceId, $untilId, $count)
-            ->with('images')
+        $query->with('images')
             ->with('user');
 
         $userId && $query->withGoodedByUser($userId);
-        $callable && $callable($query);
+    }
 
-        return $query->get();
+    public function scopeTimeline($query, $sinceId, $untilId, $count = null, $userId = null)
+    {
+        $query->withTimelineRelations($userId)
+            ->getBetween($sinceId, $untilId, $count);
     }
 
     public static function createAndLinkImage($attributes, $images)

--- a/app/User.php
+++ b/app/User.php
@@ -38,6 +38,13 @@ class User extends Authenticatable implements JWTSubject
         });
     }
 
+    public function restaurantTimeline($restaurantId, $sinceId = null, $untilId = null, $count = null)
+    {
+        return $this->getPosts($sinceId, $untilId, $count, function ($query) use ($restaurantId) {
+            $query->where('restaurant_id', $restaurantId);
+        });
+    }
+
     public function getPosts($sinceId, $untilId, $count, callable $callable = null)
     {
         $query = Post::getBetween($sinceId, $untilId, $count)

--- a/app/User.php
+++ b/app/User.php
@@ -25,25 +25,26 @@ class User extends Authenticatable implements JWTSubject
 
     public function homeTimeline($sinceId = null, $untilId = null, $count = null)
     {
-        return Post::getTimeline($sinceId, $untilId, $count, $this->user_id, function ($query) {
-            $userIds = $this->followings()->pluck('follow_user_id');
-            $userIds[] = $this->user_id;
-            $query->whereIn('user_id', $userIds);
-        });
+        $userIds = $this->followings()->pluck('follow_user_id');
+        $userIds[] = $this->user_id;
+
+        return Post::whereIn('user_id', $userIds)
+            ->timeline($sinceId, $untilId, $count, $this->user_id)
+            ->get();
     }
 
     public function userTimeline($userId, $sinceId = null, $untilId = null, $count = null)
     {
-        return Post::getTimeline($sinceId, $untilId, $count, $this->user_id, function ($query) use ($userId) {
-            $query->where('user_id', $userId);
-        });
+        return Post::where('user_id', $userId)
+            ->timeline($sinceId, $untilId, $count, $this->user_id)
+            ->get();
     }
 
     public function restaurantTimeline($restaurantId, $sinceId = null, $untilId = null, $count = null)
     {
-        return Post::getTimeline($sinceId, $untilId, $count, $this->user_id, function ($query) use ($restaurantId) {
-            $query->where('restaurant_id', $restaurantId);
-        });
+        return Post::where('restaurant_id', $restaurantId)
+            ->timeline($sinceId, $untilId, $count, $this->user_id)
+            ->get();
     }
 
     public function incrementGoodCount($amount = 1)

--- a/routes/api.php
+++ b/routes/api.php
@@ -22,6 +22,7 @@ Route::group(['prefix' => 'auth'], function ($router) {
 
 Route::get('/home_timeline', 'TimelineController@homeTimeline');
 Route::get('/user_timeline', 'TimelineController@userTimeline');
+Route::get('/restaurant_timeline', 'TimelineController@restaurantTimeline');
 
 Route::get('/rest_search', 'RestaurantSearchController@search');
 Route::post('/post', 'PostController@storePost');

--- a/tests/Unit/PostTest.php
+++ b/tests/Unit/PostTest.php
@@ -59,4 +59,16 @@ class PostTest extends TestCase
         $post = Post::withGoodedByUser($user->user_id)->find($post->getKey());
         $this->assertEquals(1, $post->goods->count());
     }
+
+    /** @test */
+    public function getTimelineLoadsRelations()
+    {
+        $post = Post::getTimeline(null, null, null)[0];
+        $this->assertTrue($post->relationLoaded('images'));
+        $this->assertTrue($post->relationLoaded('user'));
+        $this->assertFalse($post->relationLoaded('goods'));
+
+        $postWithGoods = Post::getTimeline(null, null, null, User::first()->user_id)[0];
+        $this->assertTrue($postWithGoods->relationLoaded('goods'));
+    }
 }

--- a/tests/Unit/PostTest.php
+++ b/tests/Unit/PostTest.php
@@ -20,24 +20,24 @@ class PostTest extends TestCase
     }
 
     /** @test */
-    public function getBetweenNullsReturnsAllPosts()
+    public function idBetweenNullsReturnsAllPosts()
     {
-        $this->assertEquals(Post::count(), Post::getBetween(null, null)->count());
+        $this->assertEquals(Post::count(), Post::idBetween(null, null)->count());
     }
 
     /** @test */
-    public function getBetweenGetsPostsBetweenGivenIds()
+    public function IdBetweenGetsPostsBetweenGivenIds()
     {
-        $posts = Post::getBetween(2, 7)->get();
+        $posts = Post::idBetween(2, 7)->get();
         $postKeys = $posts->sortBy('post_id')->values()->modelKeys();
 
         $this->assertEquals([3, 4, 5, 6, 7], $posts->modelKeys());
     }
 
     /** @test */
-    public function getBetweenLimitsNumOfPosts()
+    public function idBetweenLimitsNumOfPosts()
     {
-        $posts = Post::getBetween(2, 7, $count = 3)->get();
+        $posts = Post::idBetween(2, 7, $count = 3)->get();
         $postKeys = $posts->sortBy('post_id')->values()->modelKeys();
 
         $this->assertEquals([5, 6, 7], $posts->sortBy('post_id')->values()->modelKeys());

--- a/tests/Unit/PostTest.php
+++ b/tests/Unit/PostTest.php
@@ -61,14 +61,14 @@ class PostTest extends TestCase
     }
 
     /** @test */
-    public function getTimelineLoadsRelations()
+    public function withTimelineRelationsLoadsRelations()
     {
-        $post = Post::getTimeline(null, null, null)[0];
+        $post = Post::withTimelineRelations()->first();
         $this->assertTrue($post->relationLoaded('images'));
         $this->assertTrue($post->relationLoaded('user'));
         $this->assertFalse($post->relationLoaded('goods'));
 
-        $postWithGoods = Post::getTimeline(null, null, null, User::first()->user_id)[0];
+        $postWithGoods = Post::withTimelineRelations(User::first()->user_id)->first();
         $this->assertTrue($postWithGoods->relationLoaded('goods'));
     }
 }

--- a/tests/Unit/UserTest.php
+++ b/tests/Unit/UserTest.php
@@ -65,15 +65,4 @@ class UserTest extends TestCase
         $this->assertEquals(1, $posts->count());
         $this->assertEquals('aaa', $posts[0]->restaurant_id);
     }
-
-    /** @test */
-    public function getPostsLoadsRelations()
-    {
-        $user = User::first();
-
-        $post = $user->getPosts(null, null, null)[0];
-        $this->assertTrue($post->relationLoaded('goods'));
-        $this->assertTrue($post->relationLoaded('images'));
-        $this->assertTrue($post->relationLoaded('user'));
-    }
 }

--- a/tests/Unit/UserTest.php
+++ b/tests/Unit/UserTest.php
@@ -55,6 +55,18 @@ class UserTest extends TestCase
     }
     
     /** @test */
+    public function restaurantTimelineReturnsPostsOfRestaurant()
+    {
+        $user = User::first();
+        $user->posts()->save(factory(Post::class)->make(['restaurant_id' => 'aaa']));
+
+        $posts = $user->restaurantTimeline('aaa');
+
+        $this->assertEquals(1, $posts->count());
+        $this->assertEquals('aaa', $posts[0]->restaurant_id);
+    }
+
+    /** @test */
     public function getPostsLoadsRelations()
     {
         $user = User::first();


### PR DESCRIPTION
## 概要
レストランごとのタイムライン取得機能を追加

## 変更内容
* /api/restaurant_timelineで店ごとにタイムラインを取得できるように機能追加
* これまでUserモデルがタイムライン取得の処理をまとめたメソッドを持っていたけど、レストランごとの機能が登場したことでUserモデルに全てを持たすべきか怪しくなったので、とりあえずPostモデルに当該メソッドを移動。(restaurantTimelineメソッドがUserモデルにあるのはよくないけど、後日時間がある時に対応するつもり)
* PostにgetBetweenというスコープメソッドがあったけど、getという言葉が呼んだだけで実際にクエリーを実行してしまいそうな名前だと思ったのでidBetweenに変更