### PR TITLE
Feature/create go to list endpoint

### DIFF
--- a/app/Http/Controllers/ToGoController.php
+++ b/app/Http/Controllers/ToGoController.php
@@ -48,7 +48,7 @@ class ToGoController extends Controller
         $restaurant = $this->restaurantApiService->getRestaurant($request->restaurant_id);
         return ToGo::create([
             'restaurant_id' => $request->restaurant_id,
-            'location' => new Point($restaurant['latitude'], $restaurant['longitude']),
+            'location' => new Point($restaurant['latitude'], $restaurant['longitude'], 4326),
             'user_id' => Auth::id()
         ]);
     }

--- a/app/Http/Controllers/ToGoController.php
+++ b/app/Http/Controllers/ToGoController.php
@@ -21,6 +21,31 @@ class ToGoController extends Controller
         $this->restaurantApiService = $restaurantApiService;
     }
 
+    /**
+     * @OA\Get(
+     *  path="/api/goto",
+     *  summary="Gotoリスト取得",
+     *  description="指定位置の半径1キロ圏内にあるGotoリストに登録されたレストランを取得する(位置指定なしの場合、リストの全てのレストランを返す)",
+     *  operationId="getGoto",
+     *  tags={"goto"},
+     *  security={{"bearer": {}}},
+     *  @OA\Parameter(ref="#/components/parameters/goto_get_latitude"),
+     *  @OA\Parameter(ref="#/components/parameters/goto_get_longitude"),
+     *  @OA\Response(
+     *      response=401,
+     *      description="認証されていない",
+     *  ),
+     *  @OA\Response(
+     *      response=422,
+     *      description="リクエストボディに誤りがある",
+     *  ),
+     *  @OA\Response(
+     *      response=200,
+     *      description="Success",
+     *      @OA\MediaType(mediaType="application/json")
+     *  ),
+     * )
+     */
     public function index(GetToGo $request)
     {
         $query = ToGo::where('user_id', Auth::id());
@@ -43,7 +68,7 @@ class ToGoController extends Controller
      *  path="/api/goto",
      *  summary="Gotoリストに追加",
      *  description="新しいレストランをGotoリストに追加する",
-     *  operationId="storeNewPost",
+     *  operationId="storeNewGoto",
      *  tags={"goto"},
      *  security={{"bearer": {}}},
      *  @OA\RequestBody(ref="#/components/requestBodies/goto_store_request_body"),

--- a/app/Http/Controllers/ToGoController.php
+++ b/app/Http/Controllers/ToGoController.php
@@ -18,6 +18,30 @@ class ToGoController extends Controller
         $this->restaurantApiService = $restaurantApiService;
     }
 
+    /**
+     * @OA\Post(
+     *  path="/api/goto",
+     *  summary="Gotoリストに追加",
+     *  description="新しいレストランをGotoリストに追加する",
+     *  operationId="storeNewPost",
+     *  tags={"goto"},
+     *  security={{"bearer": {}}},
+     *  @OA\RequestBody(ref="#/components/requestBodies/goto_store_request_body"),
+     *  @OA\Response(
+     *      response=401,
+     *      description="認証されていない",
+     *  ),
+     *  @OA\Response(
+     *      response=422,
+     *      description="リクエストボディに誤りがある",
+     *  ),
+     *  @OA\Response(
+     *      response=201,
+     *      description="Gotoリストに追加された",
+     *      @OA\MediaType(mediaType="application/json")
+     *  ),
+     * )
+     */
     public function store(StoreToGo $request)
     {
         $restaurant = $this->restaurantApiService->getRestaurant($request->restaurant_id);

--- a/app/Http/Controllers/ToGoController.php
+++ b/app/Http/Controllers/ToGoController.php
@@ -53,4 +53,12 @@ class ToGoController extends Controller
             'user_id' => Auth::id()
         ]);
     }
+
+    public function destroy(ToGO $toGo)
+    {
+        $this->authorize('delete-togo', $toGo);
+        $toGo->delete();
+
+        return response()->json('', 204);
+    }
 }

--- a/app/Http/Controllers/ToGoController.php
+++ b/app/Http/Controllers/ToGoController.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\StoreToGo;
+use App\ToGo;
+use App\Services\GurunaviApiService;
+use Auth;
+use Illuminate\Http\Request;
+
+class ToGoController extends Controller
+{
+    private $restaurantApiService;
+
+    public function __construct(GurunaviApiService $restaurantApiService)
+    {
+        $this->middleware('auth');
+        $this->restaurantApiService = $restaurantApiService;
+    }
+
+    public function store(StoreToGo $request)
+    {
+        $restaurant = $this->restaurantApiService->getRestaurant($request->restaurant_id);
+
+        return ToGo::create([
+            'restaurant_id' => $request->restaurant_id,
+            'latitude' => $restaurant['latitude'],
+            'longitude' => $restaurant['longitude'],
+            'user_id' => Auth::id()
+        ]);
+    }
+}

--- a/app/Http/Controllers/ToGoController.php
+++ b/app/Http/Controllers/ToGoController.php
@@ -54,11 +54,33 @@ class ToGoController extends Controller
         ]);
     }
 
+    /**
+     * @OA\Delete(
+     *  path="/api/goto/{restaurant_id}",
+     *  summary="Gotoリストから削除",
+     *  description="レストレンをGotoリストから削除する",
+     *  operationId="destroyGoto",
+     *  tags={"goto"},
+     *  security={{"bearer": {}}},
+     *  @OA\Parameter(ref="#/components/parameters/goto_destroy_restaurant_id"),
+     *  @OA\Response(
+     *      response=401,
+     *      description="認証されていない",
+     *  ),
+     *  @OA\Response(
+     *      response=404,
+     *      description="ユーザのGotoリストに指定されたレストランが存在しない",
+     *  ),
+     *  @OA\Response(
+     *      response=204,
+     *      description="レストランがGotoリストから削除された",
+     *      @OA\MediaType(mediaType="application/json")
+     *  ),
+     * )
+     */
     public function destroy(ToGO $toGo)
     {
-        $this->authorize('delete-togo', $toGo);
         $toGo->delete();
-
         return response()->json('', 204);
     }
 }

--- a/app/Http/Controllers/ToGoController.php
+++ b/app/Http/Controllers/ToGoController.php
@@ -6,6 +6,7 @@ use App\Http\Requests\StoreToGo;
 use App\ToGo;
 use App\Services\GurunaviApiService;
 use Auth;
+use Grimzy\LaravelMysqlSpatial\Types\Point;
 use Illuminate\Http\Request;
 
 class ToGoController extends Controller
@@ -45,11 +46,9 @@ class ToGoController extends Controller
     public function store(StoreToGo $request)
     {
         $restaurant = $this->restaurantApiService->getRestaurant($request->restaurant_id);
-
         return ToGo::create([
             'restaurant_id' => $request->restaurant_id,
-            'latitude' => $restaurant['latitude'],
-            'longitude' => $restaurant['longitude'],
+            'location' => new Point($restaurant['latitude'], $restaurant['longitude']),
             'user_id' => Auth::id()
         ]);
     }

--- a/app/Http/Controllers/ToGoController.php
+++ b/app/Http/Controllers/ToGoController.php
@@ -3,6 +3,8 @@
 namespace App\Http\Controllers;
 
 use App\Http\Requests\StoreToGo;
+use App\Http\Requests\GetToGo;
+use App\Http\Resources\ToGo as ToGoResource;
 use App\ToGo;
 use App\Services\GurunaviApiService;
 use Auth;
@@ -17,6 +19,18 @@ class ToGoController extends Controller
     {
         $this->middleware('auth');
         $this->restaurantApiService = $restaurantApiService;
+    }
+
+    public function index(GetToGo $request)
+    {
+        $query = ToGo::where('user_id', Auth::id());
+
+        if ($request->has(['latitude', 'longitude'])) {
+            $location = new Point($request->latitude, $request->longitude, 4326);
+            $query->distance('location', $location, 1000);
+        }
+
+        return ToGoResource::collection($query->paginate(10));
     }
 
     /**

--- a/app/Http/Controllers/ToGoController.php
+++ b/app/Http/Controllers/ToGoController.php
@@ -4,7 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Http\Requests\StoreToGo;
 use App\Http\Requests\GetToGo;
-use App\Http\Resources\ToGo as ToGoResource;
+use App\Http\Resources\ToGoCollection;
 use App\ToGo;
 use App\Services\GurunaviApiService;
 use Auth;
@@ -34,6 +34,7 @@ class ToGoController extends Controller
         $toGos = $query->paginate(10);
         $this->mapRestaurantInfo($toGos->getCollection());
 
+        return new ToGoCollection($toGos);
         return ToGoResource::collection($toGos);
     }
 

--- a/app/Http/Documents/Goto.php
+++ b/app/Http/Documents/Goto.php
@@ -24,3 +24,21 @@
 *   description="Gotoリストから削除するレストランのid",
 * ),
 */
+
+/**
+* @OA\Parameter(
+*   parameter="goto_get_latitude",
+*   name="latitude",
+*   in="query",
+*   description="取得したい位置の緯度(指定時はlongitudeも必須)",
+* ),
+*/
+
+/**
+* @OA\Parameter(
+*   parameter="goto_get_longitude",
+*   name="longitude",
+*   in="query",
+*   description="取得したい位置の経度(指定時はlatitudeも必須)",
+* ),
+*/

--- a/app/Http/Documents/Goto.php
+++ b/app/Http/Documents/Goto.php
@@ -14,3 +14,13 @@
 *   ),
 * ),
 */
+
+/**
+* @OA\Parameter(
+*   parameter="goto_destroy_restaurant_id",
+*   name="restaurant_id",
+*   in="path",
+*   required=true,
+*   description="Gotoリストから削除するレストランのid",
+* ),
+*/

--- a/app/Http/Documents/Goto.php
+++ b/app/Http/Documents/Goto.php
@@ -1,0 +1,16 @@
+<?php
+
+/**
+* @OA\RequestBody(
+*   request="goto_store_request_body",
+*   required=true,
+*   @OA\JsonContent(
+*       required={"restaurant_id"},
+*       @OA\Property(
+*           property="restaurant_id",
+*           type="string",
+*           description="リストに追加するレストランのid"
+*       ),
+*   ),
+* ),
+*/

--- a/app/Http/Requests/GetToGo.php
+++ b/app/Http/Requests/GetToGo.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class GetToGo extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'latitude' => 'numeric|required_with:longitude',
+            'longitude' => 'numeric|required_with:latitude'
+        ];
+    }
+}

--- a/app/Http/Requests/StoreToGo.php
+++ b/app/Http/Requests/StoreToGo.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class storeToGo extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'restaurant_id' => [
+                'required',
+                Rule::unique('to_goes')->where(function ($query) {
+                    $query->where('user_id', $this->user()->user_id);
+                })
+            ],
+        ];
+    }
+}

--- a/app/Http/Resources/ToGo.php
+++ b/app/Http/Resources/ToGo.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class ToGo extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function toArray($request)
+    {
+        return [
+            'to_go_id' => $this->to_go_id,
+            'restaurant_id' => $this->restaurant_id,
+            'latitude' => $this->location->getLat(),
+            'longitude' => $this->location->getLng()
+        ];
+    }
+}

--- a/app/Http/Resources/ToGo.php
+++ b/app/Http/Resources/ToGo.php
@@ -16,9 +16,10 @@ class ToGo extends JsonResource
     {
         return [
             'to_go_id' => $this->to_go_id,
-            'restaurant_id' => $this->restaurant_id,
-            'latitude' => $this->location->getLat(),
-            'longitude' => $this->location->getLng()
+            // 'restaurant_id' => $this->restaurant_id,
+            // 'latitude' => $this->location->getLat(),
+            // 'longitude' => $this->location->getLng(),
+            'rest' => $this->restaurant,
         ];
     }
 }

--- a/app/Http/Resources/ToGoCollection.php
+++ b/app/Http/Resources/ToGoCollection.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Resources\Json\ResourceCollection;
+
+class ToGoCollection extends ResourceCollection
+{
+    /**
+     * Transform the resource collection into an array.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function toArray($request)
+    {
+        return [
+            'rest' => $this->pluck('restaurant')
+        ];
+    }
+}

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -36,5 +36,9 @@ class AuthServiceProvider extends ServiceProvider
         Gate::define('delete-post', function ($user, $post) {
             return $user->user_id === $post->user_id;
         });
+
+        Gate::define('delete-togo', function ($user, $toGo) {
+            return $user->user_id === $toGo->user_id;
+        });
     }
 }

--- a/app/Services/GurunaviApiService.php
+++ b/app/Services/GurunaviApiService.php
@@ -4,6 +4,7 @@ namespace App\Services;
 
 use App\Exceptions\RestaurantApiException;
 use GuzzleHttp\Client;
+use function GuzzleHttp\Psr7\build_query;
 
 class GurunaviApiService
 {
@@ -48,15 +49,22 @@ class GurunaviApiService
         $baseUrl = config('gurunavi.baseUrl');
         $apiKey = config('gurunavi.key');
         $params['keyid'] = $apiKey;
-        $requestUrl = $baseUrl . $path;
+        $requestUrl = $baseUrl . $path . '?' . $this->buildQUery($params);
+
         $client = new Client();
         $res = $client->request("GET", $requestUrl, [
-            'query' => $params,
             'http_errors' => false
         ]);
 
         $this->validateResponse($res);
         return json_decode($res->getBody(), true);
+    }
+
+    private function buildQuery($params)
+    {
+        $query = build_query($params);
+        $query = str_replace('%2C', ',', $query);
+        return $query;
     }
 
     private function validateResponse($res)

--- a/app/ToGo.php
+++ b/app/ToGo.php
@@ -8,6 +8,7 @@ class ToGo extends Model
 {
     protected $table = 'to_goes';
     protected $primaryKey = 'to_go_id';
+    protected $guarded = [];
     public $timestamps = false;
 
     public function user()

--- a/app/ToGo.php
+++ b/app/ToGo.php
@@ -3,13 +3,17 @@
 namespace App;
 
 use Auth;
+use Grimzy\LaravelMysqlSpatial\Eloquent\SpatialTrait;
 use Illuminate\Database\Eloquent\Model;
 
 class ToGo extends Model
 {
+    use SpatialTrait;
+
     protected $table = 'to_goes';
     protected $primaryKey = 'to_go_id';
     protected $guarded = [];
+    protected $spatialFields = ['location'];
     public $timestamps = false;
 
     public function user()

--- a/app/ToGo.php
+++ b/app/ToGo.php
@@ -2,6 +2,7 @@
 
 namespace App;
 
+use Auth;
 use Illuminate\Database\Eloquent\Model;
 
 class ToGo extends Model
@@ -14,5 +15,13 @@ class ToGo extends Model
     public function user()
     {
         return $this->belongsTo(User::class, 'to_go_id');
+    }
+
+    public function resolveRouteBinding($value)
+    {
+        return $this->where([
+            'restaurant_id' => $value,
+            'user_id' => Auth::id()
+        ])->firstOrFail();
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,7 @@
         "askedio/laravel-soft-cascade": "^6.0",
         "darkaonline/l5-swagger": "6.*",
         "fideloper/proxy": "^4.0",
+        "grimzy/laravel-mysql-spatial": "^3.0",
         "guzzlehttp/guzzle": "^7.0",
         "laravel/framework": "^6.2",
         "laravel/tinker": "^2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e33752823a3f60d6aa42d00a2397b6f8",
+    "content-hash": "14f0ee5d56c470e63903a3f6063bcf19",
     "packages": [
         {
             "name": "askedio/laravel-soft-cascade",
@@ -605,6 +605,170 @@
             "time": "2020-10-22T13:48:01+00:00"
         },
         {
+            "name": "geo-io/interface",
+            "version": "v1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/geo-io/interface.git",
+                "reference": "cf46fe7b013de20ab8b601238c7d91b480810644"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/geo-io/interface/zipball/cf46fe7b013de20ab8b601238c7d91b480810644",
+                "reference": "cf46fe7b013de20ab8b601238c7d91b480810644",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "GeoIO\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com"
+                }
+            ],
+            "description": "Geo I/O base interfaces.",
+            "keywords": [
+                "geo",
+                "geometry",
+                "io"
+            ],
+            "support": {
+                "issues": "https://github.com/geo-io/interface/issues",
+                "source": "https://github.com/geo-io/interface/tree/v1.0.1"
+            },
+            "time": "2016-07-28T07:17:02+00:00"
+        },
+        {
+            "name": "geo-io/wkb-parser",
+            "version": "v1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/geo-io/wkb-parser.git",
+                "reference": "cceee8f4e8b2058f3f1a0372c930140f23fe1ee1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/geo-io/wkb-parser/zipball/cceee8f4e8b2058f3f1a0372c930140f23fe1ee1",
+                "reference": "cceee8f4e8b2058f3f1a0372c930140f23fe1ee1",
+                "shasum": ""
+            },
+            "require": {
+                "geo-io/interface": "~1.0",
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "mockery/mockery": "~0.9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GeoIO\\WKB\\Parser\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com"
+                }
+            ],
+            "description": "Well-known binary (WKB) Parser.",
+            "keywords": [
+                "geo",
+                "geometry",
+                "io",
+                "parser",
+                "wkb"
+            ],
+            "support": {
+                "issues": "https://github.com/geo-io/wkb-parser/issues",
+                "source": "https://github.com/geo-io/wkb-parser/tree/master"
+            },
+            "time": "2015-06-30T04:19:13+00:00"
+        },
+        {
+            "name": "grimzy/laravel-mysql-spatial",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/grimzy/laravel-mysql-spatial.git",
+                "reference": "49b0daf1e6fc730eaf82269972f324be7dea7efb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/grimzy/laravel-mysql-spatial/zipball/49b0daf1e6fc730eaf82269972f324be7dea7efb",
+                "reference": "49b0daf1e6fc730eaf82269972f324be7dea7efb",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-pdo": "*",
+                "geo-io/wkb-parser": "^1.0",
+                "illuminate/database": "^5.2|^6.0|^7.0",
+                "jmikola/geojson": "^1.0",
+                "php": ">=5.5.9"
+            },
+            "require-dev": {
+                "doctrine/dbal": "^2.5",
+                "laravel/browser-kit-testing": "^2.0",
+                "laravel/laravel": "^5.2|^6.0|^7.0",
+                "mockery/mockery": "^0.9.9",
+                "php-coveralls/php-coveralls": "^2.0",
+                "phpunit/phpunit": "~4.8|~5.7"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0.x-dev"
+                },
+                "laravel": {
+                    "providers": [
+                        "Grimzy\\LaravelMysqlSpatial\\SpatialServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Grimzy\\LaravelMysqlSpatial\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Joseph Estefane",
+                    "email": "estefanejoe@gmail.com"
+                }
+            ],
+            "description": "MySQL spatial data types extension for Laravel.",
+            "support": {
+                "issues": "https://github.com/grimzy/laravel-mysql-spatial/issues",
+                "source": "https://github.com/grimzy/laravel-mysql-spatial/tree/master"
+            },
+            "time": "2020-04-14T03:13:36+00:00"
+        },
+        {
             "name": "guzzlehttp/guzzle",
             "version": "7.2.0",
             "source": {
@@ -835,6 +999,63 @@
                 "source": "https://github.com/guzzle/psr7/tree/1.7.0"
             },
             "time": "2020-09-30T07:37:11+00:00"
+        },
+        {
+            "name": "jmikola/geojson",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/jmikola/geojson.git",
+                "reference": "6ec3016cc0215667b7775f6ead7bd0337ad66eee"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/jmikola/geojson/zipball/6ec3016cc0215667b7775f6ead7bd0337ad66eee",
+                "reference": "6ec3016cc0215667b7775f6ead7bd0337ad66eee",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~3.7"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "GeoJson\\": "src/"
+                },
+                "classmap": [
+                    "stubs/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jeremy Mikola",
+                    "email": "jmikola@gmail.com"
+                }
+            ],
+            "description": "GeoJSON implementation for PHP",
+            "homepage": "https://github.com/jmikola/geojson",
+            "keywords": [
+                "geo",
+                "geojson",
+                "geospatial"
+            ],
+            "support": {
+                "issues": "https://github.com/jmikola/geojson/issues",
+                "source": "https://github.com/jmikola/geojson/tree/master"
+            },
+            "time": "2015-09-27T15:35:21+00:00"
         },
         {
             "name": "laravel/framework",

--- a/database/factories/ToGoFactory.php
+++ b/database/factories/ToGoFactory.php
@@ -4,11 +4,11 @@
 
 use App\ToGo;
 use Faker\Generator as Faker;
+use Grimzy\LaravelMysqlSpatial\Types\Point;
 
 $factory->define(ToGo::class, function (Faker $faker) {
     return [
         'restaurant_id' => 'kd1j800',
-        'latitude' => 1.1,
-        'longitude' => 2.2,
+        'location' => new Point(1.1, 2.2)
     ];
 });

--- a/database/factories/ToGoFactory.php
+++ b/database/factories/ToGoFactory.php
@@ -1,0 +1,14 @@
+<?php
+
+/** @var \Illuminate\Database\Eloquent\Factory $factory */
+
+use App\ToGo;
+use Faker\Generator as Faker;
+
+$factory->define(ToGo::class, function (Faker $faker) {
+    return [
+        'restaurant_id' => 'kd1j800',
+        'latitude' => 1.1,
+        'longitude' => 2.2,
+    ];
+});

--- a/database/factories/ToGoFactory.php
+++ b/database/factories/ToGoFactory.php
@@ -9,6 +9,6 @@ use Grimzy\LaravelMysqlSpatial\Types\Point;
 $factory->define(ToGo::class, function (Faker $faker) {
     return [
         'restaurant_id' => 'kd1j800',
-        'location' => new Point(1.1, 2.2)
+        'location' => new Point(1.1, 2.2, 4326)
     ];
 });

--- a/database/migrations/2021_01_25_014434_add_location_to_to_goes.php
+++ b/database/migrations/2021_01_25_014434_add_location_to_to_goes.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddLocationToToGoes extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('to_goes', function (Blueprint $table) {
+            $table->point('location');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('to_goes', function (Blueprint $table) {
+            $table->dropColumn('location');
+        });
+    }
+}

--- a/database/migrations/2021_01_25_014434_add_location_to_to_goes.php
+++ b/database/migrations/2021_01_25_014434_add_location_to_to_goes.php
@@ -14,7 +14,7 @@ class AddLocationToToGoes extends Migration
     public function up()
     {
         Schema::table('to_goes', function (Blueprint $table) {
-            $table->point('location');
+            $table->point('location', 4326);
         });
     }
 

--- a/database/migrations/2021_01_25_015638_drop_latitude_and_longitude_from_to_goes.php
+++ b/database/migrations/2021_01_25_015638_drop_latitude_and_longitude_from_to_goes.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class DropLatitudeAndLongitudeFromToGoes extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('to_goes', function (Blueprint $table) {
+            $table->dropColumn(['latitude', 'longitude']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('to_goes', function (Blueprint $table) {
+            $table->double('latitude');
+            $table->double('longitude');
+        });
+    }
+}

--- a/database/migrations/2021_01_25_015833_add_spacial_index_to_to_goes.php
+++ b/database/migrations/2021_01_25_015833_add_spacial_index_to_to_goes.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddSpacialIndexToToGoes extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('to_goes', function (Blueprint $table) {
+            $table->spatialIndex('location');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('to_goes', function (Blueprint $table) {
+            $table->dropSpatialIndex(['location']);
+        });
+    }
+}

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -21,8 +21,8 @@
         <server name="APP_ENV" value="testing"/>
         <server name="BCRYPT_ROUNDS" value="4"/>
         <server name="CACHE_DRIVER" value="array"/>
-        <server name="DB_CONNECTION" value="sqlite"/>
-        <server name="DB_DATABASE" value=":memory:"/>
+        <server name="DB_CONNECTION" value="mysql"/>
+        <server name="DB_DATABASE" value="quuta_test"/>
         <server name="MAIL_DRIVER" value="array"/>
         <server name="QUEUE_CONNECTION" value="sync"/>
         <server name="SESSION_DRIVER" value="array"/>

--- a/routes/api.php
+++ b/routes/api.php
@@ -41,3 +41,4 @@ Route::get('/follower', 'FollowController@followerIndex');
 Route::delete('/follow', 'FollowController@destroy');
 Route::get('/user/{user}', 'UserController@show');
 Route::post('/goto', 'ToGoController@store');
+Route::delete('/goto/{toGo}', 'ToGoController@destroy');

--- a/routes/api.php
+++ b/routes/api.php
@@ -40,5 +40,6 @@ Route::get('/following', 'FollowController@followingIndex');
 Route::get('/follower', 'FollowController@followerIndex');
 Route::delete('/follow', 'FollowController@destroy');
 Route::get('/user/{user}', 'UserController@show');
+Route::get('/goto', 'ToGoController@index');
 Route::post('/goto', 'ToGoController@store');
 Route::delete('/goto/{toGo}', 'ToGoController@destroy');

--- a/routes/api.php
+++ b/routes/api.php
@@ -40,3 +40,4 @@ Route::get('/following', 'FollowController@followingIndex');
 Route::get('/follower', 'FollowController@followerIndex');
 Route::delete('/follow', 'FollowController@destroy');
 Route::get('/user/{user}', 'UserController@show');
+Route::post('/goto', 'ToGoController@store');

--- a/tests/Feature/DeleteToGoTest.php
+++ b/tests/Feature/DeleteToGoTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\ToGo;
+use App\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+
+class DeleteToGoTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        factory(User::class, 2)->create();
+    }
+
+    /** @test */
+    public function itDeletesToGo()
+    {
+        $user = User::first();
+
+        ToGo::create([
+            'restaurant_id' => 'restaurantToBeDeleted',
+            'latitude' => 1.1,
+            'longitude' => 2.2,
+            'user_id' => $user->user_id,
+        ]);
+
+        $response = $this->actingAs($user)->deleteJson('/api/goto/restaurantToBeDeleted');
+
+        $response->assertStatus(204);
+        $this->assertDeleted('to_goes', [
+            'restaurant_id' => 'restaurantToBeDeleted',
+            'latitude' => 1.1,
+            'longitude' => 2.2,
+            'user_id' => $user->user_id,
+        ]);
+    }
+
+    /** @test */
+    public function itReturns404WhenUserDoesNotHaveSpecifiedToGo()
+    {
+        [$user, $other] = User::take(2)->get();
+
+        $response = $this->actingAs($user)->deleteJson('/api/goto/noSuchToGo');
+        $response->assertNotFound();
+
+        ToGo::create([
+            'restaurant_id' => 'notMine',
+            'latitude' => 1.1,
+            'longitude' => 2.2,
+            'user_id' => $other->user_id,
+        ]);
+
+        $response = $this->actingAs($user)->deleteJson('/api/goto/notMine');
+        $response->assertNotFound();
+    }
+}

--- a/tests/Feature/DeleteToGoTest.php
+++ b/tests/Feature/DeleteToGoTest.php
@@ -24,10 +24,8 @@ class DeleteToGoTest extends TestCase
     {
         $user = User::first();
 
-        ToGo::create([
+        factory(ToGo::class)->create([
             'restaurant_id' => 'restaurantToBeDeleted',
-            'latitude' => 1.1,
-            'longitude' => 2.2,
             'user_id' => $user->user_id,
         ]);
 
@@ -36,8 +34,6 @@ class DeleteToGoTest extends TestCase
         $response->assertStatus(204);
         $this->assertDeleted('to_goes', [
             'restaurant_id' => 'restaurantToBeDeleted',
-            'latitude' => 1.1,
-            'longitude' => 2.2,
             'user_id' => $user->user_id,
         ]);
     }
@@ -50,10 +46,8 @@ class DeleteToGoTest extends TestCase
         $response = $this->actingAs($user)->deleteJson('/api/goto/noSuchToGo');
         $response->assertNotFound();
 
-        ToGo::create([
+        factory(ToGo::class)->create([
             'restaurant_id' => 'notMine',
-            'latitude' => 1.1,
-            'longitude' => 2.2,
             'user_id' => $other->user_id,
         ]);
 

--- a/tests/Feature/GetToGoTest.php
+++ b/tests/Feature/GetToGoTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use App\ToGo;
 use App\User;
+use App\Services\GurunaviApiService;
 use Grimzy\LaravelMysqlSpatial\Types\Point;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
@@ -16,6 +17,14 @@ class GetToGoTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
+
+        $this->partialMock(GurunaviApiService::class, function ($mock) {
+            $mock->shouldReceive('searchRestaurants')
+                ->with(['id' => 'abc'])
+                ->andReturn([
+                    'rest' => []
+                ]);
+        });
     }
 
     /** @test */
@@ -23,6 +32,7 @@ class GetToGoTest extends TestCase
     {
         $user = factory(User::class)->create();
         $toGo = factory(ToGo::class)->create([
+            'restaurant_id' => 'abc',
             'user_id' => $user->user_id,
             'location' => new Point(10.0, 100.0, 4326)
         ]);

--- a/tests/Feature/GetToGoTest.php
+++ b/tests/Feature/GetToGoTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\ToGo;
+use App\User;
+use Grimzy\LaravelMysqlSpatial\Types\Point;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+
+class GetToGoTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    /** @test */
+    public function itGetsToGoes()
+    {
+        $user = factory(User::class)->create();
+        $toGo = factory(ToGo::class)->create([
+            'user_id' => $user->user_id,
+            'location' => new Point(10.0, 100.0, 4326)
+        ]);
+
+        $response = $this->actingAs($user)->getJson('/api/goto');
+        $response->assertOk();
+        $response->assertJsonCount(1, 'data');
+    }
+}

--- a/tests/Feature/StoreGoodTest.php
+++ b/tests/Feature/StoreGoodTest.php
@@ -35,8 +35,7 @@ class StoreGoodTest extends TestCase
         $post = $post->fresh();
         $this->assertEquals(1, $post->good_count);
 
-        $user = $user->fresh();
-        $this->assertEquals(1, $user->good_count);
+        $this->assertEquals(1, $post->user->good_count);
     }
 
     /** @test */

--- a/tests/Feature/StoreToGoTest.php
+++ b/tests/Feature/StoreToGoTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature;
 use App\ToGo;
 use App\User;
 use App\Services\GurunaviApiService;
+use Grimzy\LaravelMysqlSpatial\Types\Point;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
 use Tests\TestCase;
@@ -39,12 +40,10 @@ class StoreToGoTest extends TestCase
 
         $response->assertStatus(201);
 
-        $this->assertDatabaseHas('to_goes', [
-            'restaurant_id' => 'idOfARestaurant',
-            'latitude' => 100.000001,
-            'longitude' => 200.000002,
-            'user_id' => $user->user_id
-        ]);
+        $toGo = ToGo::where('restaurant_id', 'idOfARestaurant')->first();
+        $this->assertNotNull($toGo);
+        $this->assertEquals(100.000001, $toGo->location->getLat());
+        $this->assertEquals(200.000002, $toGo->location->getLng());
     }
     
     /** @test */

--- a/tests/Feature/StoreToGoTest.php
+++ b/tests/Feature/StoreToGoTest.php
@@ -52,10 +52,8 @@ class StoreToGoTest extends TestCase
     {
         $user = User::first();
 
-        ToGo::create([
+        factory(ToGo::class)->create([
             'restaurant_id' => 'duplicateRestaurant',
-            'latitude' => 1.1,
-            'longitude' => 2.2,
             'user_id' => $user->user_id,
         ]);
 

--- a/tests/Feature/StoreToGoTest.php
+++ b/tests/Feature/StoreToGoTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\ToGo;
+use App\User;
+use App\Services\GurunaviApiService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+
+class StoreToGoTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        factory(User::class)->create();
+
+        $this->partialMock(GurunaviApiService::class, function ($mock) {
+            $mock->shouldReceive('getRestaurant')
+                ->with('idOfARestaurant')
+                ->andReturn([
+                    'latitude' => 100.000001,
+                    'longitude' => 200.000002,
+                ]);
+        });
+    }
+
+    /** @test */
+    public function itSavesToGo()
+    {
+        $user = User::first();
+        $response = $this->actingAs($user)->postJson('/api/goto', [
+            'restaurant_id' => 'idOfARestaurant'
+        ]);
+
+        $response->assertStatus(201);
+
+        $this->assertDatabaseHas('to_goes', [
+            'restaurant_id' => 'idOfARestaurant',
+            'latitude' => 100.000001,
+            'longitude' => 200.000002,
+            'user_id' => $user->user_id
+        ]);
+    }
+    
+    /** @test */
+    public function itRejectsUserAddingSameRestaurant()
+    {
+        $user = User::first();
+
+        ToGo::create([
+            'restaurant_id' => 'duplicateRestaurant',
+            'latitude' => 1.1,
+            'longitude' => 2.2,
+            'user_id' => $user->user_id,
+        ]);
+
+        $response = $this->actingAs($user)->postJson('/api/goto', [
+            'restaurant_id' => 'duplicateRestaurant'
+        ]);
+
+        $response->assertStatus(422);
+    }
+}

--- a/tests/Feature/StoreToGoTest.php
+++ b/tests/Feature/StoreToGoTest.php
@@ -24,8 +24,8 @@ class StoreToGoTest extends TestCase
             $mock->shouldReceive('getRestaurant')
                 ->with('idOfARestaurant')
                 ->andReturn([
-                    'latitude' => 100.000001,
-                    'longitude' => 200.000002,
+                    'latitude' => 30.000000,
+                    'longitude' => 100.000000,
                 ]);
         });
     }
@@ -42,8 +42,8 @@ class StoreToGoTest extends TestCase
 
         $toGo = ToGo::where('restaurant_id', 'idOfARestaurant')->first();
         $this->assertNotNull($toGo);
-        $this->assertEquals(100.000001, $toGo->location->getLat());
-        $this->assertEquals(200.000002, $toGo->location->getLng());
+        $this->assertEquals(30.000000, $toGo->location->getLat());
+        $this->assertEquals(100.000000, $toGo->location->getLng());
     }
     
     /** @test */

--- a/tests/Unit/PostTest.php
+++ b/tests/Unit/PostTest.php
@@ -5,6 +5,7 @@ namespace Tests\Unit;
 use App\Good;
 use App\Post;
 use App\User;
+use DB;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 use UserPostSeeder;
@@ -17,6 +18,17 @@ class PostTest extends TestCase
     {
         parent::setUp();
         $this->seed(UserPostSeeder::class);
+    }
+
+    protected function tearDown(): void
+    {
+        DB::statement('alter table posts auto_increment = 1');
+        parent::tearDownAfterClass();
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        \Artisan::call('migrate:fresh');
     }
 
     /** @test */

--- a/tests/Unit/PostTest.php
+++ b/tests/Unit/PostTest.php
@@ -5,6 +5,7 @@ namespace Tests\Unit;
 use App\Good;
 use App\Post;
 use App\User;
+use Artisan;
 use DB;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
@@ -17,18 +18,12 @@ class PostTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
+
+        $this->beforeApplicationDestroyed(function () {
+            DB::statement('alter table posts auto_increment = 1');
+        });
+
         $this->seed(UserPostSeeder::class);
-    }
-
-    protected function tearDown(): void
-    {
-        DB::statement('alter table posts auto_increment = 1');
-        parent::tearDownAfterClass();
-    }
-
-    public static function tearDownAfterClass(): void
-    {
-        \Artisan::call('migrate:fresh');
     }
 
     /** @test */


### PR DESCRIPTION
## 概要
Gotoリストの追加、取得、および削除ができる機能を追加。

## 変更内容
* to_goesテーブルがlatitude, longitude列を持っていたけど、処理を高速化したい気がするのでPoint型で持ってSpatial Indexを使えるように変更。
* 上記変更に伴ってsqliteではテストできなくなったので、テスト時はmysqlのテスト用データベースで実行するように変更。
* laravel-mysql-spatialを導入
* 現状to_goesテーブルがrestaurant_id以外のレストラン情報を持っておらず、id取得後に別にレストラン情報を取得する必要がある。レストラン情報を別テーブルに保持するかの議論が必要だけど、納期が近いので一旦取得したidでGurunavi Apiを叩くことにした。(Gurunavi Apiの仕様でidは10個までしか同時検索できないので10個ずつペジネーションしてる)
