### PR TITLE
Fix ぐるなびがエラーを返した時500で落ちてしまってたバグ

### DIFF
--- a/app/Services/GurunaviApiService.php
+++ b/app/Services/GurunaviApiService.php
@@ -72,7 +72,7 @@ class GurunaviApiService
         $status = $res->getStatusCode();
 
         if ($status / 100 !== 2) {
-            $message = json_decode($res->getBody(), false)->error->message;
+            $message = json_decode($res->getBody(), false)->error[0]->message;
             throw new RestaurantApiException($message);
         }
     }


### PR DESCRIPTION
## 概要
ぐるなびApiに対してのリクエストが失敗したときに返却されたエラーメッセージを適切に返せず500エラーになってたのを修正